### PR TITLE
Imaginary step finite difference option implemented for finite sensit…

### DIFF
--- a/External/ode15sf/ode15sf.m
+++ b/External/ode15sf/ode15sf.m
@@ -804,9 +804,9 @@ while ~done
     end
     if nonNegative && (err <= rtol) && any(ynew(idxNonNegative)<0)
       if normcontrol
-        errNN = norm( max(0,-ynew(idxNonNegative)) ) * invwt;
+        errNN = norm( max(0,-real(ynew(idxNonNegative))) ) * invwt; % Added real() around ynew to fix complex number case
       else
-        errNN = norm( max(0,-ynew(idxNonNegative)) ./ thresholdNonNegative, inf);
+        errNN = norm( max(0,-real(ynew(idxNonNegative)) ) ./ thresholdNonNegative, inf); % Added real() around ynew to fix complex number case
       end
       if errNN > rtol
         err = errNN;
@@ -896,7 +896,7 @@ while ~done
   
   NNreset_dif = false;
   if nonNegative && any(ynew(idxNonNegative) < 0)
-    NNidx = idxNonNegative(ynew(idxNonNegative) < 0); % logical indexing
+    NNidx = idxNonNegative(real(ynew(idxNonNegative)) < 0); % logical indexing, added real() around ynew to deal with complex case
     ynew(NNidx) = 0;
     if normcontrol
       normynew = norm(ynew);

--- a/Source/FiniteObjectiveGradient.m
+++ b/Source/FiniteObjectiveGradient.m
@@ -45,6 +45,13 @@ function D = FiniteObjectiveGradient(m, con, obj, opts)
 %                 nonegative scalar {1e-9} ]
 %           Absolute tolerance of the integration. If a cell vector is
 %           provided, a different AbsTol will be used for each experiment.
+%       .ImaginaryStep [ logical scalar {false} ]
+%           If set to true, use an imaginary finite difference step. This
+%           has the advantage of not requiring the subtraction of two large
+%           numbers, increasing the stability of the result, but comes at
+%           the cost of larger computational cost from evaluating
+%           expressions with complex numbers. If set to false (the
+%           default), a real finite difference step is used.
 %       .Verbose [ nonnegative integer scalar {1} ]
 %           Bigger number displays more progress information
 %
@@ -69,6 +76,8 @@ defaultOpts.Verbose          = 1;
 
 defaultOpts.RelTol           = [];
 defaultOpts.AbsTol           = [];
+
+defaultOpts.ImaginaryStep    = false;
 
 defaultOpts.UseParams        = nan;
 defaultOpts.UseSeeds         = nan;
@@ -132,11 +141,17 @@ for iT = 1:nT
     T_up = T0;
     
     % Change current parameter by finite amount
-    if opts.Normalized
-        diff = T_i * 1e-8;
+    if opts.ImaginaryStep
+        imagfactor = 1i;
     else
-        diff = 1e-8;
+        imagfactor = 1;
     end
+    if opts.Normalized
+        normfactor = T_i;
+    else
+        normfactor = 1;
+    end
+    diff = normfactor * imagfactor * 1e-8;
     
     % Compute objective values
     T_up(iT) = T_up(iT) + diff;
@@ -144,9 +159,13 @@ for iT = 1:nT
     G_up = computeObj(m, con, obj, opts);
 
     % Compute D
-    if opts.Normalized
-        D(iT) = T_i * (G_up - G) / diff;
+    if opts.ImaginaryStep
+        D(iT) = imag(G_up) / imag(diff);
     else
-        D(iT) = (G_up - G) / diff ;
+        D(iT) = (G_up - G) / diff;
     end
+    if opts.Normalized
+        D(iT) = T_i * D(iT);
+    end
+    
 end

--- a/Source/FiniteSimulateCurvature.m
+++ b/Source/FiniteSimulateCurvature.m
@@ -72,7 +72,7 @@ defaultOpts.Verbose          = 1;
 defaultOpts.RelTol           = [];
 defaultOpts.AbsTol           = [];
 
-defaultOpts.Normalized       = true;
+defaultOpts.ImaginaryStep    = false;
 
 defaultOpts.UseParams        = nan;
 defaultOpts.UseSeeds         = nan;

--- a/Source/FiniteSimulateSensitivity.m
+++ b/Source/FiniteSimulateSensitivity.m
@@ -75,6 +75,8 @@ defaultOpts.Verbose          = 1;
 defaultOpts.RelTol           = [];
 defaultOpts.AbsTol           = [];
 
+defaultOpts.ImaginaryStep    = false;
+
 defaultOpts.Normalized       = true;
 defaultOpts.UseParams        = 1:m.nk;
 defaultOpts.UseSeeds         = [];

--- a/Source/FiniteSimulateSensitivity.m
+++ b/Source/FiniteSimulateSensitivity.m
@@ -77,7 +77,6 @@ defaultOpts.AbsTol           = [];
 
 defaultOpts.ImaginaryStep    = false;
 
-defaultOpts.Normalized       = true;
 defaultOpts.UseParams        = 1:m.nk;
 defaultOpts.UseSeeds         = [];
 defaultOpts.UseInputControls = [];

--- a/Source/eventDropsBelow.m
+++ b/Source/eventDropsBelow.m
@@ -1,3 +1,5 @@
 function eve = eventDropsBelow(m, output, threshold)
 
-eve = Event(-1, @(t,y)y(output)-threshold);
+% real() call is needed for imaginary finite differences to work with this
+% event
+eve = Event(-1, @(t,y)real(y(output))-threshold);

--- a/Source/private/accumulateOdeFwdSimp.m
+++ b/Source/private/accumulateOdeFwdSimp.m
@@ -78,15 +78,15 @@ for k = 1:(N-1)
         % Start or restart integration after an event
         if isempty(events)
             [sim_x, sim_y] = ode15sf(der, t_ode, ic, sim_opts);
-            sim_sol.x = sim_x';
-            sim_sol.y = sim_y';
+            sim_sol.x = sim_x.';
+            sim_sol.y = sim_y.';
         else
             [sim_x, sim_y, sim_xe, sim_ye, sim_ie] = ode15sf(der, t_ode, ic, sim_opts);
-            sim_sol.x = sim_x';
-            sim_sol.y = sim_y';
-            sim_sol.xe = sim_xe';
-            sim_sol.ye = sim_ye';
-            sim_sol.ie = sim_ie';
+            sim_sol.x = sim_x.';
+            sim_sol.y = sim_y.';
+            sim_sol.xe = sim_xe.';
+            sim_sol.ye = sim_ye.';
+            sim_sol.ie = sim_ie.';
         end
         
         % Check if integration failed when it shouldn't have

--- a/Source/private/integrateCurvSimpFinite.m
+++ b/Source/private/integrateCurvSimpFinite.m
@@ -59,19 +59,13 @@ int.dxdT = int0.dxdT;
 int.dudT = int0.dudT;
 int.dydT = int0.dydT;
 
-
 % Change each parameter a bit and resimulate
 d2xdT2_all = zeros(nx*nT*nT,nt);
 d2udT2_all = zeros(nu*nT*nT,nt);
 d2ydT2_all = zeros(ny*nT*nT,nt);
 
-Trepmat_nxbynT = repmat(vec(T0).', nx, 1);
-Trepmat_nubynT = repmat(vec(T0).', nu, 1);
-Trepmat_nybynT = repmat(vec(T0).', ny, 1);
-
 for iT = 1:nT
     % Set baseline parameters
-    T_i = T0(iT);
     T_up = T0;
     
     % Change current parameter by finite amount

--- a/Source/private/integrateSensSimpFinite.m
+++ b/Source/private/integrateSensSimpFinite.m
@@ -61,15 +61,16 @@ dudT_all = zeros(nu*nT,nt);
 dydT_all = zeros(ny*nT,nt);
 for iT = 1:nT
     % Set baseline parameters
-    Ti = T0(iT);
+    T_i = T0(iT);
     T_up = T0;
     
     % Change current parameter by finite amount
-    if opts.Normalized
-        diff = Ti * 1e-8;
+    if opts.ImaginaryStep
+        imagfactor = 1i;
     else
-        diff = 1e-8;
+        imagfactor = 1;
     end
+    diff = imagfactor * 1e-8;
     
     % Simulate difference
     T_up(iT) = T_up(iT) + diff;
@@ -79,15 +80,23 @@ for iT = 1:nT
     % Difference
     ind_x_start = (iT-1)*nx+1;
     ind_x_end = (iT-1)*nx+nx;
-    dxdT_all(ind_x_start:ind_x_end,:) = (int_up.x - x_all) ./ diff;
-
+    
     ind_u_start = (iT-1)*nu+1;
     ind_u_end = (iT-1)*nu+nu;
-    dudT_all(ind_u_start:ind_u_end,:) = (int_up.u - u_all) ./ diff;
-
+    
     ind_y_start = (iT-1)*ny+1;
     ind_y_end = (iT-1)*ny+ny;
-    dydT_all(ind_y_start:ind_y_end,:) = (int_up.y - y_all) ./ diff;
+    
+    if opts.ImaginaryStep
+        dxdT_all(ind_x_start:ind_x_end,:) = imag(int_up.x) ./ imag(diff);
+        dudT_all(ind_u_start:ind_u_end,:) = imag(int_up.u) ./ imag(diff);
+        dydT_all(ind_y_start:ind_y_end,:) = imag(int_up.y) ./ imag(diff);
+    else
+        dxdT_all(ind_x_start:ind_x_end,:) = (int_up.x - x_all) ./ diff;
+        dudT_all(ind_u_start:ind_u_end,:) = (int_up.u - u_all) ./ diff;
+        dydT_all(ind_y_start:ind_y_end,:) = (int_up.y - y_all) ./ diff;
+    end
+    
 end
 
 int.dxdT = dxdT_all(:,1:nt_discrete);

--- a/Testing/UT05_Sensitivity.m
+++ b/Testing/UT05_Sensitivity.m
@@ -89,6 +89,7 @@ sim1 = SimulateSensitivity(m, con, max(tGet), opts);
 
 sim2 = SimulateSensitivity(m, con, obsSelect, opts);
 
+opts.ImaginaryStep = true;
 sim3 = FiniteSimulateSensitivity(m, con, obsSelect, opts);
 
 a.verifyEqual(sim1.dydT(tGet,1:m.ny), sim3.dydT, 'RelTol', 0.001, 'AbsTol', 1e-4)
@@ -98,6 +99,7 @@ end
 function verifySensitivityEvent(a, m, con, obs, opts)
 sim1 = SimulateSensitivity(m, con, obs, opts);
 
+opts.ImaginaryStep = true;
 sim2 = FiniteSimulateSensitivity(m, con, obs, opts);
 
 a.verifyEqual(sim1.dyedT, sim2.dyedT, 'RelTol', 0.001, 'AbsTol', 1e-4)

--- a/Testing/UT06_Curvature.m
+++ b/Testing/UT06_Curvature.m
@@ -121,6 +121,7 @@ sim1 = SimulateCurvature(m, con, max(tGet), opts);
 
 sim2 = SimulateCurvature(m, con, obsSelect, opts);
 
+opts.ImaginaryStep = true;
 sim3 = FiniteSimulateCurvature(m, con, obsSelect, opts);
 
 a.verifyEqual(size(sim2.d2xdT2), [m.nx*nT*nT, numel(tGet)])
@@ -134,6 +135,7 @@ end
 function verifyCurvatureEvent(a, m, con, obs, opts)
 sim1 = SimulateCurvature(m, con, obs, opts);
 
+opts.ImaginaryStep = true;
 sim2 = FiniteSimulateCurvature(m, con, obs, opts);
 
 a.verifyEqual(sim1.d2yedT2, sim2.d2yedT2, 'RelTol', 0.001, 'AbsTol', 1e-4)

--- a/Testing/UT08_Gradient.m
+++ b/Testing/UT08_Gradient.m
@@ -17,6 +17,7 @@ opts.UseAdjoint = true;
 Dadj = ObjectiveGradient(m, con(1), obj, opts);
 
 % Discrete
+opts.ImaginaryStep = true;
 Ddisc = FiniteObjectiveGradient(m, con(1), obj, opts);
 
 a.verifyEqual(Dfwd, Ddisc, 'RelTol', 0.001)
@@ -31,6 +32,7 @@ opts.UseAdjoint = true;
 Dadj = ObjectiveGradient(m, con(2), obj, opts);
 
 % Discrete
+opts.ImaginaryStep = true;
 Ddisc = FiniteObjectiveGradient(m, con(2), obj, opts);
 
 a.verifyEqual(Dfwd, Ddisc, 'RelTol', 0.001)
@@ -45,6 +47,7 @@ opts.UseAdjoint = true;
 Dadj = ObjectiveGradient(m, con(3), obj, opts);
 
 % Discrete
+opts.ImaginaryStep = true;
 Ddisc = FiniteObjectiveGradient(m, con(3), obj, opts);
 
 a.verifyEqual(Dfwd, Ddisc, 'RelTol', 0.001)
@@ -68,6 +71,7 @@ opts.UseAdjoint = true;
 Dadj = ObjectiveGradient(m, con, obj, opts);
 
 % Discrete
+opts.ImaginaryStep = true;
 Ddisc = FiniteObjectiveGradient(m, con, obj, opts);
 
 a.verifyEqual(size(Dfwd), [nT,1])
@@ -91,6 +95,7 @@ opts.UseAdjoint = true;
 Dadj = ObjectiveGradient(m, con, obj, opts);
 
 % Discrete
+opts.ImaginaryStep = true;
 Ddisc = FiniteObjectiveGradient(m, con, obj, opts);
 
 a.verifyEqual(size(Dfwd), [nT,1])
@@ -114,6 +119,7 @@ opts.UseAdjoint = true;
 Dadj = ObjectiveGradient(m, con, obj, opts);
 
 % Discrete
+opts.ImaginaryStep = true;
 Ddisc = FiniteObjectiveGradient(m, con, obj, opts);
 
 a.verifyEqual(size(Dfwd), [nT,1])

--- a/Testing/UT09_Hessian.m
+++ b/Testing/UT09_Hessian.m
@@ -51,6 +51,7 @@ nT = nnz(opts.UseParams)+nnz(opts.UseSeeds)+nnz(opts.UseInputControls)+nnz(opts.
 
 Hfwd = ObjectiveHessian(m, con, obj, opts);
 
+opts.ImaginaryStep = true;
 Hdisc = FiniteObjectiveHessian(m, con, obj, opts);
 
 a.verifyEqual(size(Hfwd), [nT,nT])

--- a/Testing/tUT00a_ImaginaryStepFD.m
+++ b/Testing/tUT00a_ImaginaryStepFD.m
@@ -1,0 +1,280 @@
+% This testing function provides a number of tests of the imaginary step
+% finite differences calculator of sensitivities, curvatures, gradients,
+% and hessians. It is primarily to be used to debug problems with complex
+% numbers in Kronecker functions. If you suspect that problems with complex
+% numbers are causing tests to fail (such as use of ' instead of .' causing
+% unwanted conjugation of complex numbers), use these tests to help
+% determine whether the problem can be isolated to the imaginary step
+% finite differences routine.
+%
+% This test isn't run with the normal suite of tests because it is rather
+% slow (it takes about 5 minutes to complete) and is somewhat redundant
+% (errors that occur here will almost always also occur in the other unit
+% tests).
+%
+% The tests below will often fail because the imaginary step finite
+% difference returns slightly different results than the real step finite
+% difference. There probably isn't a problem as long as the difference in
+% results is small and the comparison of the imaginary step finite
+% difference to the analytic integration passes. The failure in this case
+% results from roundoff errors in the real step finite difference results
+% originating from 1e-8 being too small of a step size. (The imaginary step
+% avoids calculating a small difference between two nearly equal large
+% numbers and doesn't have roundoff error problems).
+
+function tests = UT00a_ImaginaryStepFD()
+tests = functiontests(localfunctions);
+end
+
+
+%% Sensitivity
+
+function tests = testImaginaryStepFD_MassActionSensitivity(a)
+[m, con, unused, opts] = simple_model();
+m = m.Update(rand(m.nk,1)+1);
+con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
+tGet = 1:6;
+
+verifySensitivity(a, m, con, tGet, opts)
+end
+
+function tests = testImaginaryStepFD_AnalyticSensitivity(a)
+[m, con, ~, opts] = michaelis_menten_model();
+m = m.Update(rand(m.nk,1)+m.k+1);
+con = con.Update(rand(con.ns,1)+con.s+1, rand(con.nq,1)+con.q+1, rand(con.nh,1)+con.h+1);
+tGet = 1:10;
+
+verifySensitivity(a, m, con, tGet, opts)
+end
+
+function tests = testImaginaryStepFD_MassActionEventSensitivity(a)
+[m, con, unused, opts] = simple_model();
+m = m.Update(rand(m.nk,1)+1);
+con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
+
+eve1 = eventDropsBelow(m, 10, 15);
+eve2 = eventDropsBelow(m, 1, 2);
+obs = observationEvents(6, [eve1;eve2]);
+
+verifySensitivityEvent(a, m, con, obs, opts)
+end
+
+function tests = testImaginaryStepFD_AnalyticEventSensitivity(a)
+[m, con, ~, opts, eve] = michaelis_menten_model();
+m = m.Update(rand(m.nk,1)+m.k+1);
+con = con.Update(rand(con.ns,1)+con.s+1, rand(con.nq,1)+con.q+1, rand(con.nh,1)+con.h+1);
+
+obs = observationEvents(10, eve);
+
+verifySensitivityEvent(a, m, con, obs, opts)
+end
+
+function verifySensitivity(a, m, con, tGet, opts)
+obsSelect = observationSelect(tGet);
+
+simint = SimulateSensitivity(m, con, obsSelect, opts);
+
+opts.ImaginaryStep = false;
+simreal_simple = FiniteSimulateSensitivity(m, con, obsSelect, opts);
+
+opts.ImaginaryStep = true;
+simimag_simple = FiniteSimulateSensitivity(m, con, obsSelect, opts);
+% Complex finite sensitivities aren't implemented yet
+%simimag_complex = FiniteSimulateSensitivity(m, con, max(tGet), opts);
+
+%a.verifyEqual(simimag_complex.dydT(tGet,1:m.ny), simreal.dydT, 'RelTol', 0.001, 'AbsTol', 1e-4)
+a.verifyEqual(simimag_simple.dydT, simreal_simple.dydT, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step returned different values than using a real step.')
+a.verifyEqual(simimag_simple.dydT, simint.dydT, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step differed from integration of analytic derivatives.')
+end
+
+function verifySensitivityEvent(a, m, con, obs, opts)
+
+simint = SimulateSensitivity(m, con, obs, opts);
+
+opts.ImaginaryStep = false;
+simreal = FiniteSimulateSensitivity(m, con, obs, opts);
+
+opts.ImaginaryStep = true;
+simimag = FiniteSimulateSensitivity(m, con, obs, opts);
+
+a.verifyEqual(simreal.dyedT, simimag.dyedT, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step returned different values than using a real step.')
+a.verifyEqual(simint.dyedT, simimag.dyedT, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step differed from integration of analytic derivatives.')
+
+end
+
+%% Curvature
+
+function tests = testImaginaryStepFD_MassActionCurvature(a)
+
+[m, con, unused, opts] = simple_model();
+m = m.Update(rand(m.nk,1)+1);
+con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
+tGet = 1:6;
+
+verifyCurvature(a, m, con, tGet, opts)
+
+end
+
+function tests = testImaginaryStepFD_AnalyticCurvature(a)
+
+[m, con, ~, opts] = michaelis_menten_model();
+m = m.Update(rand(m.nk,1)+m.k+1);
+con = con.Update(rand(con.ns,1)+con.s+1, rand(con.nq,1)+con.q+1, rand(con.nh,1)+con.h+1);
+tGet = 1:10;
+
+verifyCurvature(a, m, con, tGet, opts)
+
+end
+
+function tests = testImaginaryStepFD_MassActionEventCurvature(a)
+
+[m, con, unused, opts] = simple_model();
+m = m.Update(rand(m.nk,1)+1);
+con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
+
+eve1 = eventDropsBelow(m, 10, 15);
+eve2 = eventDropsBelow(m, 1, 2);
+obs = observationEvents(6, [eve1;eve2]);
+
+verifyCurvatureEvent(a, m, con, obs, opts)
+
+end
+
+function tests = testImaginaryStepFD_AnalyticEventCurvature(a)
+
+[m, con, ~, opts, eve] = michaelis_menten_model();
+m = m.Update(rand(m.nk,1)+m.k+1);
+con = con.Update(rand(con.ns,1)+con.s+1, rand(con.nq,1)+con.q+1, rand(con.nh,1)+con.h+1);
+
+obs = observationEvents(10, eve);
+
+verifyCurvatureEvent(a, m, con, obs, opts)
+
+end
+
+function verifyCurvature(a, m, con, tGet, opts)
+
+nT = nnz(opts.UseParams)+nnz(opts.UseSeeds)+nnz(opts.UseInputControls)+nnz(opts.UseDoseControls);
+obsSelect = observationSelect(tGet);
+
+simint = SimulateCurvature(m, con, obsSelect, opts);
+
+opts.ImaginaryStep = false;
+simreal_simple = FiniteSimulateCurvature(m, con, obsSelect, opts);
+
+opts.ImaginaryStep = true;
+simimag_simple = FiniteSimulateCurvature(m, con, obsSelect, opts);
+
+% Complex finite curvature is not implemented
+
+a.verifyEqual(size(simimag_simple.d2xdT2), [m.nx*nT*nT, numel(tGet)])
+a.verifyEqual(size(simimag_simple.d2udT2), [m.nu*nT*nT, numel(tGet)])
+a.verifyEqual(size(simimag_simple.d2ydT2), [m.ny*nT*nT, numel(tGet)])
+
+a.verifyEqual(simreal_simple.d2ydT2, simimag_simple.d2ydT2, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step returned different values than using a real step.')
+a.verifyEqual(simint.d2ydT2, simimag_simple.d2ydT2, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step differed from integration of analytic derivatives.')
+
+end
+
+function verifyCurvatureEvent(a, m, con, obs, opts)
+
+simint = SimulateCurvature(m, con, obs, opts);
+
+opts.ImaginaryStep = false;
+simreal = FiniteSimulateCurvature(m, con, obs, opts);
+
+opts.ImaginaryStep = true;
+simimag = FiniteSimulateCurvature(m, con, obs, opts);
+
+a.verifyEqual(simreal.d2yedT2, simimag.d2yedT2, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step returned different values than using a real step.')
+a.verifyEqual(simint.d2yedT2, simimag.d2yedT2, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step differed from integration of analytic derivatives.')
+
+end
+
+%% Gradient
+
+function tests = testImaginaryStepFD_MassActionGradient(a)
+[m, con, obj, opts] = simple_model();
+
+verifyGradient(a, m, con, obj, opts)
+end
+
+function tests = testImaginaryStepFD_SteadyStateGradient(a)
+simpleopts.steadyState = true;
+[m, con, obj, opts] = simple_model(simpleopts);
+
+verifyGradient(a, m, con, obj, opts)
+end
+
+function tests = testImaginaryStepFD_AnalyticGradient(a)
+[m, con, obj, opts] = michaelis_menten_model();
+
+verifyGradient(a, m, con, obj, opts)
+end
+
+function verifyGradient(a, m, con, obj, opts)
+nT = nnz(opts.UseParams)+nnz(opts.UseSeeds)+nnz(opts.UseInputControls)+nnz(opts.UseDoseControls);
+
+% Integration of analytic derivatives
+Dinteg = ObjectiveGradient(m, con, obj, opts);
+
+% Real FD
+opts.ImaginaryStep = false;
+Dreal = FiniteObjectiveGradient(m, con, obj, opts);
+
+% Imaginary FD
+opts.ImaginaryStep = true;
+Dimag = FiniteObjectiveGradient(m, con, obj, opts);
+
+a.verifyEqual(size(Dimag), [nT,1])
+
+a.verifyEqual(Dimag, Dreal, 'RelTol', 0.001, 'Finite differences using an imaginary step returned different values than using a real step.')
+a.verifyEqual(Dimag, Dinteg, 'RelTol', 0.001, 'Finite differences using an imaginary step differed from integration of analytic derivatives.')
+end
+
+%% Hessian
+
+function tests = testImaginaryStepFD_MassActionHessian(a)
+[m, con, obj, opts] = simple_model();
+m = m.Update(rand(m.nk,1)+1);
+con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
+
+verifyHessian(a, m, con, obj, opts)
+end
+
+function tests = testImaginaryStepFD_SteadyStateHessian(a)
+simpleopts.steadyState = true;
+[m, con, obj, opts] = simple_model(simpleopts);
+m = m.Update(rand(m.nk,1)+1);
+con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
+
+verifyHessian(a, m, con, obj, opts)
+end
+
+function tests = testImaginaryStepFD_AnalyticHessian(a)
+[m, con, obj, opts] = michaelis_menten_model();
+m = m.Update(rand(m.nk,1)+1);
+con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
+
+verifyHessian(a, m, con, obj, opts)
+end
+
+function verifyHessian(a, m, con, obj, opts)
+nT = nnz(opts.UseParams)+nnz(opts.UseSeeds)+nnz(opts.UseInputControls)+nnz(opts.UseDoseControls);
+
+% Integration of analytic derivatives
+Hinteg = ObjectiveHessian(m, con, obj, opts);
+
+% Finite differences with real step
+opts.ImaginaryStep = false;
+Hreal = FiniteObjectiveHessian(m, con, obj, opts);
+
+% Finite differences with imaginary step
+opts.ImaginaryStep = true;
+Himag = FiniteObjectiveHessian(m, con, obj, opts);
+
+a.verifyEqual(size(Himag), [nT,nT])
+
+a.verifyEqual(Hreal, Himag, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step returned different values than using a real step.')
+a.verifyEqual(Hinteg, Himag, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step differed from integration of analytic derivatives.')
+end


### PR DESCRIPTION
…ivity, curvature, gradient, and hessian functions.

By default, real step finite differences is still used. An optional test was added to compare results from imaginary step FD, real step FD, and integration of the analytic derivatives. Unit tests were updated to use the imaginary step option to avoid problems with roundoff errors.