### PR TITLE
Fixed curvature normalization bugs, changed name of imaginary step FD…

### DIFF
--- a/Source/FiniteObjectiveGradient.m
+++ b/Source/FiniteObjectiveGradient.m
@@ -45,7 +45,7 @@ function D = FiniteObjectiveGradient(m, con, obj, opts)
 %                 nonegative scalar {1e-9} ]
 %           Absolute tolerance of the integration. If a cell vector is
 %           provided, a different AbsTol will be used for each experiment.
-%       .ImaginaryStep [ logical scalar {false} ]
+%       .ComplexStep [ logical scalar {false} ]
 %           If set to true, use an imaginary finite difference step. This
 %           has the advantage of not requiring the subtraction of two large
 %           numbers, increasing the stability of the result, but comes at
@@ -77,7 +77,7 @@ defaultOpts.Verbose          = 1;
 defaultOpts.RelTol           = [];
 defaultOpts.AbsTol           = [];
 
-defaultOpts.ImaginaryStep    = false;
+defaultOpts.ComplexStep    = false;
 
 defaultOpts.Normalized       = true;
 defaultOpts.UseParams        = 1:m.nk;
@@ -146,7 +146,7 @@ for iT = 1:nT
     else
         norm_factor = 1;
     end
-    if opts.ImaginaryStep
+    if opts.ComplexStep
         imag_factor = 1i;
     else
         imag_factor = 1;
@@ -159,7 +159,7 @@ for iT = 1:nT
     G_up = computeObj(m, con, obj, opts);
 
     % Compute D
-    if opts.ImaginaryStep
+    if opts.ComplexStep
         D(iT) = imag(G_up) ./ step_size;
     else
         D(iT) = (G_up - G) ./ step_size;

--- a/Source/FiniteObjectiveHessian.m
+++ b/Source/FiniteObjectiveHessian.m
@@ -26,7 +26,7 @@ function [H, All] = FiniteObjectiveHessian(m, con, obj, opts)
 %                          the normalized hessian will be computed. The
 %                          normalized hessian is normalized with respect to
 %                          the values of the parameters. Default = true
-%           .ImaginaryStep - Scalar boolean. If set to true, use an
+%           .ComplexStep - Scalar boolean. If set to true, use an
 %                           imaginary finite difference step. This has the
 %                           advantage of not requiring the subtraction of
 %                           two large numbers, increasing the stability of
@@ -69,7 +69,7 @@ defaultOpts.Verbose        = 1;
 defaultOpts.RelTol         = [];
 defaultOpts.AbsTol         = [];
 
-defaultOpts.ImaginaryStep  = false;
+defaultOpts.ComplexStep  = false;
 
 defaultOpts.UseParams        = 1:m.nk;
 defaultOpts.UseSeeds         = [];
@@ -140,7 +140,7 @@ for iT = 1:nT
     else
         norm_factor = 1;
     end
-    if opts.ImaginaryStep
+    if opts.ComplexStep
         imag_factor = 1i;
     else
         imag_factor = 1;
@@ -153,7 +153,7 @@ for iT = 1:nT
     [~, D_up] = computeObjGrad(m, con, obj, opts);
 
     % Compute D
-    if opts.ImaginaryStep
+    if opts.ComplexStep
         H(:,iT) = imag(D_up) ./ step_size;
     else
         H(:,iT) = (D_up - D) ./ step_size;

--- a/Source/FiniteSimulateCurvature.m
+++ b/Source/FiniteSimulateCurvature.m
@@ -72,7 +72,7 @@ defaultOpts.Verbose          = 1;
 defaultOpts.RelTol           = [];
 defaultOpts.AbsTol           = [];
 
-defaultOpts.ImaginaryStep    = false;
+defaultOpts.ComplexStep    = false;
 
 defaultOpts.Normalized       = true;
 defaultOpts.UseParams        = 1:m.nk;

--- a/Source/FiniteSimulateSensitivity.m
+++ b/Source/FiniteSimulateSensitivity.m
@@ -75,7 +75,7 @@ defaultOpts.Verbose          = 1;
 defaultOpts.RelTol           = [];
 defaultOpts.AbsTol           = [];
 
-defaultOpts.ImaginaryStep    = false;
+defaultOpts.ComplexStep    = false;
 
 defaultOpts.Normalized       = true;
 defaultOpts.UseParams        = 1:m.nk;

--- a/Source/private/integrateCurvSimp.m
+++ b/Source/private/integrateCurvSimp.m
@@ -19,12 +19,6 @@ d2xdT2Start = nx+nx*nT+1;
 d2xdT2End   = nx+nx*nT+nx*nT*nT;
 normalized = opts.Normalized;
 T = collectActiveParameters(m, con, opts.UseParams, opts.UseSeeds, {opts.UseInputControls}, {opts.UseDoseControls});
-T_stack_x = vec(repmat(row(T), nx,1));
-T_stack_u = vec(repmat(row(T), nu,1));
-T_stack_y = vec(repmat(row(T), ny,1));
-TT_stack_x = vec(repmat(row(T), nx*nT,1)) .* vec(repmat(row(T), nx,nT));
-TT_stack_u = vec(repmat(row(T), nu*nT,1)) .* vec(repmat(row(T), nu,nT));
-TT_stack_y = vec(repmat(row(T), ny*nT,1)) .* vec(repmat(row(T), ny,nT));
 
 dkdT = sparse(find(opts.UseParams), 1:nTk, 1, nk, nT);
 
@@ -151,15 +145,9 @@ for it = 1:nt
 end
 
 if normalized
-    % Normalize sensitivities
-    int.dxdT = bsxfun(@times, int.dxdT, T_stack_x);
-    int.dudT = bsxfun(@times, int.dudT, T_stack_u);
-    int.dydT = bsxfun(@times, int.dydT, T_stack_y);
-
-    % Normalize curvature
-    int.d2xdT2 = bsxfun(@times, int.d2xdT2, TT_stack_x);
-    int.d2udT2 = bsxfun(@times, int.d2udT2, TT_stack_u);
-    int.d2ydT2 = bsxfun(@times, int.d2ydT2, TT_stack_y);
+    [int.dxdT, int.d2xdT2] = normalizeDerivatives(T, int.dxdT, int.d2xdT2);
+    [int.dudT, int.d2udT2] = normalizeDerivatives(T, int.dudT, int.d2udT2);
+    [int.dydT, int.d2ydT2] = normalizeDerivatives(T, int.dydT, int.d2ydT2);
 end
 
 nte = numel(sol.ie);
@@ -222,14 +210,9 @@ for it = 1:nte
 end
 
 if normalized
-    % Normalize events
-    int.dxedT = bsxfun(@times, int.dxedT, T_stack_x);
-    int.duedT = bsxfun(@times, int.duedT, T_stack_u);
-    int.dyedT = bsxfun(@times, int.dyedT, T_stack_y);
-    
-    int.d2xedT2 = bsxfun(@times, int.d2xedT2, TT_stack_x);
-    int.d2uedT2 = bsxfun(@times, int.d2uedT2, TT_stack_u);
-    int.d2yedT2 = bsxfun(@times, int.d2yedT2, TT_stack_y);
+    [int.dxedT, int.d2xedT2] = normalizeDerivatives(T, int.dxedT, int.d2xedT2);
+    [int.duedT, int.d2uedT2] = normalizeDerivatives(T, int.duedT, int.d2uedT2);
+    [int.dyedT, int.d2yedT2] = normalizeDerivatives(T, int.dyedT, int.d2yedT2);
 end
 
 int.sol = sol;

--- a/Source/private/integrateCurvSimpFinite.m
+++ b/Source/private/integrateCurvSimpFinite.m
@@ -76,7 +76,7 @@ for iT = 1:nT
     else
         norm_factor = 1;
     end
-    if opts.ImaginaryStep
+    if opts.ComplexStep
         imag_factor = 1i;
     else
         imag_factor = 1;
@@ -98,7 +98,7 @@ for iT = 1:nT
     ind_yT_start = (iT-1)*ny*nT+1;
     ind_yT_end = (iT-1)*ny*nT+ny*nT;
     
-    if opts.ImaginaryStep
+    if opts.ComplexStep
         d2xdT2_all(ind_xT_start:ind_xT_end,:) = imag(int_up.dxdT) ./ step_size;
         d2udT2_all(ind_uT_start:ind_uT_end,:) = imag(int_up.dudT) ./ step_size;
         d2ydT2_all(ind_yT_start:ind_yT_end,:) = imag(int_up.dydT) ./ step_size;

--- a/Source/private/integrateSensComp.m
+++ b/Source/private/integrateSensComp.m
@@ -12,10 +12,7 @@ nT  = nTk + nTs + nTq + nTh;
 dxdTStart = nx+1;
 dxdTEnd   = nx+nx*nT;
 normalized = opts.Normalized;
-T = real(collectActiveParameters(m, con, opts.UseParams, opts.UseSeeds, {opts.UseInputControls}, {opts.UseDoseControls}));
-T_stack_x = vec(repmat(row(T), nx,1));
-T_stack_u = vec(repmat(row(T), nu,1));
-T_stack_y = vec(repmat(row(T), ny,1));
+T = collectActiveParameters(m, con, opts.UseParams, opts.UseSeeds, {opts.UseInputControls}, {opts.UseDoseControls});
 
 y = m.y;
 u = con.u;
@@ -113,9 +110,9 @@ end
 
 if normalized
     % Normalize events
-    int.dxedT = bsxfun(@times, int.dxedT, T_stack_x);
-    int.duedT = bsxfun(@times, int.duedT, T_stack_u);
-    int.dyedT = bsxfun(@times, int.dyedT, T_stack_y);
+    int.dxedT = normalizeDerivatives(T, int.dxedT);
+    int.duedT = normalizeDerivatives(T, int.duedT);
+    int.dyedT = normalizeDerivatives(T, int.dyedT);
 end
 
 int.sol = sol;
@@ -203,7 +200,7 @@ int.sol = sol;
         val = devals(sol, t, dxdTStart:dxdTEnd); % xT_t
         
         if normalized
-            val = bsxfun(@times, val, T_stack_x);
+            val = normalizeDerivatives(T, val);
         end
     end
 
@@ -219,7 +216,7 @@ int.sol = sol;
         end
         
         if normalized
-            val = bsxfun(@times, val, T_stack_u);
+            val = normalizeDerivatives(T, val);
         end
     end
 

--- a/Source/private/integrateSensSimp.m
+++ b/Source/private/integrateSensSimp.m
@@ -13,7 +13,7 @@ nT  = nTk + nTs + nTq + nTh;
 dxdTStart = nx+1;
 dxdTEnd   = nx+nx*nT;
 normalized = opts.Normalized;
-T = real(collectActiveParameters(m, con, opts.UseParams, opts.UseSeeds, {opts.UseInputControls}, {opts.UseDoseControls}));
+T = collectActiveParameters(m, con, opts.UseParams, opts.UseSeeds, {opts.UseInputControls}, {opts.UseDoseControls});
 T_stack_x = vec(repmat(row(T), nx,1));
 T_stack_u = vec(repmat(row(T), nu,1));
 T_stack_y = vec(repmat(row(T), ny,1));
@@ -99,9 +99,9 @@ end
 
 if normalized
     % Normalize sensitivities
-    int.dxdT = bsxfun(@times, int.dxdT, T_stack_x);
-    int.dudT = bsxfun(@times, int.dudT, T_stack_u);
-    int.dydT = bsxfun(@times, int.dydT, T_stack_y);
+    int.dxdT = normalizeDerivatives(T, int.dxdT);
+    int.dudT = normalizeDerivatives(T, int.dudT);
+    int.dydT = normalizeDerivatives(T, int.dydT);
 end
 
 nte = numel(sol.ie);
@@ -129,9 +129,9 @@ end
 
 if normalized
     % Normalize events
-    int.dxedT = bsxfun(@times, int.dxedT, T_stack_x);
-    int.duedT = bsxfun(@times, int.duedT, T_stack_u);
-    int.dyedT = bsxfun(@times, int.dyedT, T_stack_y);
+    int.dxedT = normalizeDerivatives(T, int.dxedT);
+    int.duedT = normalizeDerivatives(T, int.duedT);
+    int.dyedT = normalizeDerivatives(T, int.dyedT);
 end
 
 int.sol = sol;
@@ -177,7 +177,7 @@ int.sol = sol;
             u_t = u(t);            
             x = joint(1:nx); % x_
             dxdT = reshape(joint(dxdTStart:dxdTEnd), nx,nT); % x_T
-            
+
             % Compute d/dx(dfdT)
             d2fdxdT = sparse(d2fdx2(t,x,u_t) * dxdT) + d2fdTdx(t,x,u_t); % fx_T
             d2fdxdT = spermute132(d2fdxdT, [nx,nx,nT], [nx*nT,nx]);

--- a/Source/private/integrateSensSimpFinite.m
+++ b/Source/private/integrateSensSimpFinite.m
@@ -72,7 +72,7 @@ for iT = 1:nT
     else
         norm_factor = 1;
     end
-    if opts.ImaginaryStep
+    if opts.ComplexStep
         imag_factor = 1i;
     else
         imag_factor = 1;
@@ -94,7 +94,7 @@ for iT = 1:nT
     ind_y_start = (iT-1)*ny+1;
     ind_y_end = (iT-1)*ny+ny;
     
-    if opts.ImaginaryStep
+    if opts.ComplexStep
         dxdT_all(ind_x_start:ind_x_end,:) = imag(int_up.x) ./ step_size;
         dudT_all(ind_u_start:ind_u_end,:) = imag(int_up.u) ./ step_size;
         dydT_all(ind_y_start:ind_y_end,:) = imag(int_up.y) ./ step_size;

--- a/Source/private/normalizeDerivatives.m
+++ b/Source/private/normalizeDerivatives.m
@@ -1,0 +1,81 @@
+function [dadT, d2adT2] = normalizeDerivatives(T, dadT, d2adT2)
+% [dadT, d2adT2] = normalizeDerivatives(T, dadT, d2adT2)
+% Convert sensitivities da/dT and/or curvatures d2a/dT2 at various times t
+% into da/d(logT) or d2a/d(logT)2. a can be x (the states), u (the inputs),
+% or y (the outputs). T is the list of used parameters.
+%
+% Input arguments:
+%   T:      Vector of parameters chosen by UseParams, UseSeeds,
+%           UseInputControls, and UseSeedControls
+%   dadT:   na*nT-by-nt matrix of sensitivities of a with respect to T. na
+%           is the number of values in a, nT is the number of used parameters,
+%           and nt is the number of time points for which values are
+%           provided.
+%   d2adT2: (optional) na*nT*nT-by-nt matrix of unnormalized curvatures of a with
+%           respect to T.
+%
+% Output arguments:
+%   dadT:   Normalized sensitivities da/dlogT.
+%   d2adT2: Normalized curvatures d2a/dlogT2. Only returned if unnormalized
+%           curvatures are provided.
+
+
+order = nargin - 1;
+
+nT = numel(T);
+nt = size(dadT, 2);
+na = size(dadT,1)/nT;
+
+if order >= 1
+    
+    T_stack_a = vec(repmat(row(T), na, 1));
+    dadT = bsxfun(@times, dadT, T_stack_a);
+    
+    if order >= 2
+        
+        assert(size(d2adT2,1) == nT.^2.*na, 'KroneckerBio:normalizeDerivatives:d2adT2RowSizeMismatch', 'd2adT2 did not have na*nT*nT rows. This is probably a Kronecker bug.')
+        assert(size(d2adT2,2) == nt, 'KroneckerBio:normalizeDerivatives:d2adT2ColumnSizeMismatch', 'd2adT2 did not have nt columns. This is probably a Kronecker bug.')
+        
+        TT_stack_a = vec(repmat(row(T), na*nT,1)) .* vec(repmat(row(T), na,nT));
+        d2adT2 = bsxfun(@times, d2adT2, TT_stack_a) + getNormalizationTerm(dadT);
+        
+    end
+    
+end
+
+    function dadT_diag_allt = getNormalizationTerm(dadT)
+        % This function performs diagonal expansion for each time point's
+        % sensitivities, then turns the result into a column vector, which
+        % is stored in the respective time column of an (na*nT*nT)-by-nt
+        % matrix. The resulting matrix matches the size of the curvature
+        % matrices.
+        dadT_diag_allt = zeros(na*nT*nT, nt);
+        for ti = 1:nt
+            dadT_diag = diagonalExpansion(dadT(:,ti));
+            dadT_diag_allt(:,ti) = dadT_diag(:);
+        end
+    end
+
+
+    function dadT_diag = diagonalExpansion(dadT)
+        % "Diagonally expanding" an na-by-nT matrix dadT means making an
+        % (na*nT)-by-nT matrix like so:
+        %
+        %   [dadT(:,1) 0 0 .  . . 0
+        %    0 dadT(:,2) 0
+        %    0  0 dadT(:,3)
+        %    .              .
+        %    .                .
+        %    0                  dadT(:,nT)]
+        %
+        % where 0 indicates an na-by-1 vector of zeros.
+        
+        dadT_linind = sub2ind([na nT nT], repmat((1:na).',nT,1), vec(repmat(1:nT, na, 1)), vec(repmat(1:nT, na, 1)));
+        dadT_diag = zeros(na*nT, nT);
+        dadT_diag(dadT_linind) = dadT(:);
+        
+    end
+
+
+
+end

--- a/Testing/UT05_Sensitivity.m
+++ b/Testing/UT05_Sensitivity.m
@@ -77,7 +77,7 @@ verifySensitivityEvent(a, m, con, obs, opts)
 end
 
 function verifySensitivity(a, m, con, tGet, opts)
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 obsSelect = observationSelect(tGet);
 
 opts.Normalized = false;
@@ -98,7 +98,7 @@ a.verifyEqual(sim5.dydT, sim6.dydT, 'RelTol', 0.001, 'AbsTol', 1e-4)
 end
 
 function verifySensitivityEvent(a, m, con, obs, opts)
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 
 opts.Normalized = false;
 sim1 = SimulateSensitivity(m, con, obs, opts);

--- a/Testing/UT06_Curvature.m
+++ b/Testing/UT06_Curvature.m
@@ -83,7 +83,7 @@ end
 function verifyCurvature(a, m, con, tGet, opts)
 nT = nnz(opts.UseParams)+nnz(opts.UseSeeds)+nnz(opts.UseInputControls)+nnz(opts.UseDoseControls);
 obsSelect = observationSelect(tGet);
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 
 opts.Normalized = false;
 sim1 = SimulateCurvature(m, con, max(tGet), opts);
@@ -107,7 +107,7 @@ a.verifyEqual(sim5.d2ydT2, sim6.d2ydT2, 'RelTol', 0.001, 'AbsTol', 1e-4)
 end
 
 function verifyCurvatureEvent(a, m, con, obs, opts)
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 
 opts.Normalized = false;
 sim1 = SimulateCurvature(m, con, obs, opts);

--- a/Testing/UT08_Gradient.m
+++ b/Testing/UT08_Gradient.m
@@ -69,7 +69,7 @@ verifyGradient(a, m, con, obj, opts)
 end
 
 function verifyGradient(a, m, con, obj, opts)
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 nT = nnz(opts.UseParams)+nnz(opts.UseSeeds)+nnz(opts.UseInputControls)+nnz(opts.UseDoseControls);
 
 opts.Normalized = false;

--- a/Testing/UT09_Hessian.m
+++ b/Testing/UT09_Hessian.m
@@ -69,7 +69,7 @@ verifyHessian(a, m, con, obj, opts)
 end
 
 function verifyHessian(a, m, con, obj, opts)
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 nT = nnz(opts.UseParams)+nnz(opts.UseSeeds)+nnz(opts.UseInputControls)+nnz(opts.UseDoseControls);
 
 opts.Normalized = false;

--- a/Testing/tUT00a_ComplexStepFD.m
+++ b/Testing/tUT00a_ComplexStepFD.m
@@ -22,14 +22,14 @@
 % avoids calculating a small difference between two nearly equal large
 % numbers and doesn't have roundoff error problems).
 
-function tests = UT00a_ImaginaryStepFD()
+function tests = UT00a_ComplexStepFD()
 tests = functiontests(localfunctions);
 end
 
 
 %% Sensitivity
 
-function tests = testImaginaryStepFD_MassActionSensitivity(a)
+function tests = testComplexStepFD_MassActionSensitivity(a)
 [m, con, unused, opts] = simple_model();
 m = m.Update(rand(m.nk,1)+1);
 con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
@@ -38,7 +38,7 @@ tGet = 1:6;
 verifySensitivity(a, m, con, tGet, opts)
 end
 
-function tests = testImaginaryStepFD_AnalyticSensitivity(a)
+function tests = testComplexStepFD_AnalyticSensitivity(a)
 [m, con, ~, opts] = michaelis_menten_model();
 m = m.Update(rand(m.nk,1)+m.k+1);
 con = con.Update(rand(con.ns,1)+con.s+1, rand(con.nq,1)+con.q+1, rand(con.nh,1)+con.h+1);
@@ -47,7 +47,7 @@ tGet = 1:10;
 verifySensitivity(a, m, con, tGet, opts)
 end
 
-function tests = testImaginaryStepFD_MassActionEventSensitivity(a)
+function tests = testComplexStepFD_MassActionEventSensitivity(a)
 [m, con, unused, opts] = simple_model();
 m = m.Update(rand(m.nk,1)+1);
 con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
@@ -59,7 +59,7 @@ obs = observationEvents(6, [eve1;eve2]);
 verifySensitivityEvent(a, m, con, obs, opts)
 end
 
-function tests = testImaginaryStepFD_AnalyticEventSensitivity(a)
+function tests = testComplexStepFD_AnalyticEventSensitivity(a)
 [m, con, ~, opts, eve] = michaelis_menten_model();
 m = m.Update(rand(m.nk,1)+m.k+1);
 con = con.Update(rand(con.ns,1)+con.s+1, rand(con.nq,1)+con.q+1, rand(con.nh,1)+con.h+1);
@@ -74,10 +74,10 @@ obsSelect = observationSelect(tGet);
 
 simint = SimulateSensitivity(m, con, obsSelect, opts);
 
-opts.ImaginaryStep = false;
+opts.ComplexStep = false;
 simreal_simple = FiniteSimulateSensitivity(m, con, obsSelect, opts);
 
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 simimag_simple = FiniteSimulateSensitivity(m, con, obsSelect, opts);
 % Complex finite sensitivities aren't implemented yet
 %simimag_complex = FiniteSimulateSensitivity(m, con, max(tGet), opts);
@@ -91,10 +91,10 @@ function verifySensitivityEvent(a, m, con, obs, opts)
 
 simint = SimulateSensitivity(m, con, obs, opts);
 
-opts.ImaginaryStep = false;
+opts.ComplexStep = false;
 simreal = FiniteSimulateSensitivity(m, con, obs, opts);
 
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 simimag = FiniteSimulateSensitivity(m, con, obs, opts);
 
 a.verifyEqual(simreal.dyedT, simimag.dyedT, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step returned different values than using a real step.')
@@ -104,7 +104,7 @@ end
 
 %% Curvature
 
-function tests = testImaginaryStepFD_MassActionCurvature(a)
+function tests = testComplexStepFD_MassActionCurvature(a)
 
 [m, con, unused, opts] = simple_model();
 m = m.Update(rand(m.nk,1)+1);
@@ -115,7 +115,7 @@ verifyCurvature(a, m, con, tGet, opts)
 
 end
 
-function tests = testImaginaryStepFD_AnalyticCurvature(a)
+function tests = testComplexStepFD_AnalyticCurvature(a)
 
 [m, con, ~, opts] = michaelis_menten_model();
 m = m.Update(rand(m.nk,1)+m.k+1);
@@ -126,7 +126,7 @@ verifyCurvature(a, m, con, tGet, opts)
 
 end
 
-function tests = testImaginaryStepFD_MassActionEventCurvature(a)
+function tests = testComplexStepFD_MassActionEventCurvature(a)
 
 [m, con, unused, opts] = simple_model();
 m = m.Update(rand(m.nk,1)+1);
@@ -140,7 +140,7 @@ verifyCurvatureEvent(a, m, con, obs, opts)
 
 end
 
-function tests = testImaginaryStepFD_AnalyticEventCurvature(a)
+function tests = testComplexStepFD_AnalyticEventCurvature(a)
 
 [m, con, ~, opts, eve] = michaelis_menten_model();
 m = m.Update(rand(m.nk,1)+m.k+1);
@@ -159,10 +159,10 @@ obsSelect = observationSelect(tGet);
 
 simint = SimulateCurvature(m, con, obsSelect, opts);
 
-opts.ImaginaryStep = false;
+opts.ComplexStep = false;
 simreal_simple = FiniteSimulateCurvature(m, con, obsSelect, opts);
 
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 simimag_simple = FiniteSimulateCurvature(m, con, obsSelect, opts);
 
 % Complex finite curvature is not implemented
@@ -180,10 +180,10 @@ function verifyCurvatureEvent(a, m, con, obs, opts)
 
 simint = SimulateCurvature(m, con, obs, opts);
 
-opts.ImaginaryStep = false;
+opts.ComplexStep = false;
 simreal = FiniteSimulateCurvature(m, con, obs, opts);
 
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 simimag = FiniteSimulateCurvature(m, con, obs, opts);
 
 a.verifyEqual(simreal.d2yedT2, simimag.d2yedT2, 'RelTol', 0.001, 'AbsTol', 1e-4, 'Finite differences using an imaginary step returned different values than using a real step.')
@@ -193,20 +193,20 @@ end
 
 %% Gradient
 
-function tests = testImaginaryStepFD_MassActionGradient(a)
+function tests = testComplexStepFD_MassActionGradient(a)
 [m, con, obj, opts] = simple_model();
 
 verifyGradient(a, m, con, obj, opts)
 end
 
-function tests = testImaginaryStepFD_SteadyStateGradient(a)
+function tests = testComplexStepFD_SteadyStateGradient(a)
 simpleopts.steadyState = true;
 [m, con, obj, opts] = simple_model(simpleopts);
 
 verifyGradient(a, m, con, obj, opts)
 end
 
-function tests = testImaginaryStepFD_AnalyticGradient(a)
+function tests = testComplexStepFD_AnalyticGradient(a)
 [m, con, obj, opts] = michaelis_menten_model();
 
 verifyGradient(a, m, con, obj, opts)
@@ -219,11 +219,11 @@ nT = nnz(opts.UseParams)+nnz(opts.UseSeeds)+nnz(opts.UseInputControls)+nnz(opts.
 Dinteg = ObjectiveGradient(m, con, obj, opts);
 
 % Real FD
-opts.ImaginaryStep = false;
+opts.ComplexStep = false;
 Dreal = FiniteObjectiveGradient(m, con, obj, opts);
 
 % Imaginary FD
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 Dimag = FiniteObjectiveGradient(m, con, obj, opts);
 
 a.verifyEqual(size(Dimag), [nT,1])
@@ -234,7 +234,7 @@ end
 
 %% Hessian
 
-function tests = testImaginaryStepFD_MassActionHessian(a)
+function tests = testComplexStepFD_MassActionHessian(a)
 [m, con, obj, opts] = simple_model();
 m = m.Update(rand(m.nk,1)+1);
 con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
@@ -242,7 +242,7 @@ con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
 verifyHessian(a, m, con, obj, opts)
 end
 
-function tests = testImaginaryStepFD_SteadyStateHessian(a)
+function tests = testComplexStepFD_SteadyStateHessian(a)
 simpleopts.steadyState = true;
 [m, con, obj, opts] = simple_model(simpleopts);
 m = m.Update(rand(m.nk,1)+1);
@@ -251,7 +251,7 @@ con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
 verifyHessian(a, m, con, obj, opts)
 end
 
-function tests = testImaginaryStepFD_AnalyticHessian(a)
+function tests = testComplexStepFD_AnalyticHessian(a)
 [m, con, obj, opts] = michaelis_menten_model();
 m = m.Update(rand(m.nk,1)+1);
 con = con.Update(rand(con.ns,1)+1, rand(con.nq,1)+1, rand(con.nh,1)+1);
@@ -266,11 +266,11 @@ nT = nnz(opts.UseParams)+nnz(opts.UseSeeds)+nnz(opts.UseInputControls)+nnz(opts.
 Hinteg = ObjectiveHessian(m, con, obj, opts);
 
 % Finite differences with real step
-opts.ImaginaryStep = false;
+opts.ComplexStep = false;
 Hreal = FiniteObjectiveHessian(m, con, obj, opts);
 
 % Finite differences with imaginary step
-opts.ImaginaryStep = true;
+opts.ComplexStep = true;
 Himag = FiniteObjectiveHessian(m, con, obj, opts);
 
 a.verifyEqual(size(Himag), [nT,nT])


### PR DESCRIPTION
… to complex step FD

During normalization, curvature was neglecting to add in a lower-order derivative term arising from the product rule. Normalization has been moved to its own function to reduce repetitious code. References to imaginary step finite differences were changed to be named complex step finite differences.