### PR TITLE
Fix massaction loading and reaction name bug

### DIFF
--- a/Source/FinalizeModel.m
+++ b/Source/FinalizeModel.m
@@ -219,6 +219,7 @@ for i = 1:ny
     % Check/qualify species in output expression
     if is(m, 'Model.MassActionAmount')
         outputSpecies = expr(:,1)';
+        outputSpecies = outputSpecies(~cellfun(@isempty,outputSpecies)); % species name may be empty, indicating constant
         [unambiguousSpecies, unqualified] = qualifyCompartment(outputSpecies);
         expr(unqualified,1) = unambiguousSpecies(unqualified)';
     elseif is(m, 'Model.Analytic')

--- a/Source/LoadModelMassAction.m
+++ b/Source/LoadModelMassAction.m
@@ -20,7 +20,7 @@ function m = LoadModelMassAction(files)
 %   will define that component's properties. All others by that same name
 %   will be silently overwritten.
 
-% (c) 2015 David R Hagen & Bruce Tidor
+% (c) 2016 David R Hagen & Bruce Tidor
 % This work is released under the MIT license.
 
 %% Initialize the model
@@ -30,64 +30,75 @@ m = InitializeModelMassActionAmount('');
 if ischar(files)
     files = {files};
 end
-nFiles = numel(files);
+n_files = numel(files);
 
 % Check that files exist
-for i = 1:nFiles
+for i = 1:n_files
     assert(exist(files{i}, 'file') == 2, 'KroneckerBio:LoadModelMassAction:FileNotFound', 'File %s was not found', files{i})
 end
 
 %% Loop over each file
 decimal_regex = '^[+]?([0-9]*\.)?[0-9]+([eE][-+]?[0-9]+)?$';
 
-for iFile = 1:nFiles
+for i_file = 1:n_files
     % Open file
-    fid = fopen(files{iFile});
+    fid = fopen(files{i_file});
     
     % Initialize
     mode = 0;
-    lineNumber = 0;
+    line_number = 0;
     
-    % Loop over all lines in code
+    % Loop over all lines in file
     while true % break on -1
         % Get next line
         line = fgetl(fid);
-        lineNumber = lineNumber + 1;
+        line_number = line_number + 1;
         
         % Break if end of file is encountered
         if line == -1
             break
         end
         
-        % Skip if line is empty or begins with a "#"
-        if isempty(line) || ~isempty(regexp(line, '^\s*#|^\s*$', 'once'))
+        % Strip leading and trailing whitespace
+        line = strtrim(line);
+        
+        % Strip comments ('#' until end of line)
+        %   Ignore '#' inside double-quotes '"'
+        comment_inds = regexp(line, '#(?=([^"]*"[^"]*")*[^"]*$)');
+        if ~isempty(comment_inds)
+            line = line(1:comment_inds(1)-1);
+        end
+        
+        % Skip if line is empty
+        %   Comment lines starting with '#' are skipped in combination with above
+        if isempty(line)
             continue
         end
         
         % Check if mode switching line is encountered
         % First character is a "%"
-        isSwitchMode = ~isempty(regexp(line, '^\s*%', 'once'));
+        is_switch_mode = ~isempty(regexp(line, '^%', 'once'));
         
-        if isSwitchMode
-            [match, payload] = regexp(line, '^\s*%*\s*\w*', 'match', 'split', 'once');
+        if is_switch_mode
+            [match, payload] = regexp(line, '^%\s*\w+', 'match', 'split', 'once');
             payload = payload{2}; % Only want the end, not the starting empty string
-            match = regexp(match, '\w*', 'match');
-
+            match = regexp(match, '\w+', 'match', 'once');
+            
             if strcmpi(match, 'compartments')
                 % Switch mode
                 mode = 1;
                 
                 % Extract model name
-                modelName = regexp(payload, '".*"|[^\s]*', 'match', 'once');
-                modelName = regexp(modelName, '[^"]*', 'match', 'once'); % Strip quotes
-                m = RenameModel(m, modelName);
+                model_name = regexp(payload, '".*"|[^\s]*', 'match', 'once');
+                model_name = regexp(model_name, '[^"]*', 'match', 'once'); % Strip quotes
+                m = RenameModel(m, model_name);
             elseif strcmpi(match, 'inputs')
                 % Switch mode
                 mode = 2;
                 
                 % Extract default compartment from payload
-                compartment = regexp(payload, '".*"|[^.,\s]*', 'match');
-                assert(numel(compartment) == 1, 'KroneckerBio:LoadModelMassAction:SpeciesCompartments', 'Line %i in %s specified the beginning of an Input section but exactly one compartment was not provided: %s', lineNumber, files{iFile}, line)
+                compartment = regexp(payload, '"[^"]*"|[^."\s]+', 'match');
+                assert(numel(compartment) == 1, 'KroneckerBio:LoadModelMassAction:SpeciesCompartments', 'Line %i in %s specified the beginning of an Input section but exactly one compartment was not provided: %s', line_number, files{i_file}, line)
                 
                 % Standardize compartment as a string
                 if isempty(compartment)
@@ -101,10 +112,10 @@ for iFile = 1:nFiles
             elseif strcmpi(match, 'states')
                 % Switch mode
                 mode = 4;
-                                
+                
                 % Extract default compartment from payload
-                compartment = regexp(payload, '".*"|[^.,\s]*', 'match');
-                assert(numel(compartment) == 1, 'KroneckerBio:LoadModelMassAction:SpeciesCompartments', 'Line %i in %s specified the beginning of an States section but exactly one compartment was not provided: %s', lineNumber, files{iFile}, line)
+                compartment = regexp(payload, '"[^"]*"|[^."\s]+', 'match');
+                assert(numel(compartment) == 1, 'KroneckerBio:LoadModelMassAction:SpeciesCompartments', 'Line %i in %s specified the beginning of an States section but exactly one compartment was not provided: %s', line_number, files{i_file}, line)
                 
                 % Standardize compartment as a string
                 if isempty(compartment)
@@ -112,7 +123,7 @@ for iFile = 1:nFiles
                 else
                     compartment = compartment{1};
                 end
-
+                
             elseif strcmpi(match, 'outputs')
                 % Switch mode
                 mode = 5;
@@ -123,50 +134,46 @@ for iFile = 1:nFiles
                 % Switch mode
                 mode = 7;
             else
-                error('KroneckerBio:LoadModelMassAction:UnrecognizedSectionHeader', 'Line %i in %s had an unrecognized section header: %s', lineNumber, files{iFile}, line)
+                error('KroneckerBio:LoadModelMassAction:UnrecognizedSectionHeader', 'Line %i in %s had an unrecognized section header: %s', line_number, files{i_file}, line)
             end
         else
             % Process entries
+            
+            % Tokenize
+            tokens = vec(regexp(line, '"[^"]*"|[^"\s]+','match'));
+            
+            % Strip quotes
+            for i_tok = 1:numel(tokens)
+                tokens{i_tok} = regexp(tokens{i_tok}, '[^"]*', 'match', 'once');
+            end
+            
             if mode == 1
-                % Compartments
-                tokens = vec(regexp(line, ',|".*"|[^\s,]*','match'));
-                assert(numel(tokens) >= 3, 'KroneckerBio:LoadModelMassAction:InsufficientCompartmentInformation', 'Line %i in %s does not provide the name, dimension, and size required for a compartment: %s', lineNumber, files{iFile}, line)
-                
-                % Strip quotes
-                for iTok = 1:numel(tokens)
-                    tokens{iTok} = regexp(tokens{iTok}, '[^"]*', 'match', 'once');
-                end
+                %% Compartments
+                assert(numel(tokens) >= 3, 'KroneckerBio:LoadModelMassAction:InsufficientCompartmentInformation', 'Line %i in %s does not provide the name, dimension, and size required for a compartment: %s', line_number, files{i_file}, line)
                 
                 % Extract name
-                assert(~isempty(regexp(tokens{1}, '^[^\s,.]*$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidCompartmentName', 'Line %i in %s has an invalid compartment name: %s', lineNumber, files{iFile}, line)
+                assert(~isempty(regexp(tokens{1}, '^[^.]+$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidCompartmentName', 'Line %i in %s has an invalid compartment name: %s', line_number, files{i_file}, line)
                 name = tokens{1};
                 
                 % Extract dimension
-                assert(~isempty(regexp(tokens{2}, '^0|1|2|3$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidCompartmentDimension', 'Line %i in %s has an invalid compartment dimension: %s', lineNumber, files{iFile}, line)
+                assert(~isempty(regexp(tokens{2}, '^0|1|2|3$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidCompartmentDimension', 'Line %i in %s has an invalid compartment dimension: %s', line_number, files{i_file}, line)
                 dim = str2double(tokens{2});
                 
-                % Second token is value
-                assert(~isempty(regexp(tokens{3}, decimal_regex, 'once')), 'KroneckerBio:LoadModelMassAction:InvalidCompartmentSize', 'Line %i in %s has an invalid compartment size: %s', lineNumber, files{iFile}, line)
-                value = eval(tokens{3});
+                % Extract value/size
+                tokens = tokens(3:end);
+                exprs = extract_values(tokens);
                 
                 % Add compartment
-                m = AddCompartment(m, name, dim, value);
+                m = AddCompartment(m, name, dim, exprs);
             elseif mode == 2
-                % Inputs
-                tokens = vec(regexp(line, ',|".*"|[^\s,]*','match'));
-                
-                % Strip quotes
-                for iTok = 1:numel(tokens)
-                    tokens{iTok} = regexp(tokens{iTok}, '[^"]*', 'match', 'once');
-                end
-                
+                %% Inputs
                 % Extract name
-                assert(~isempty(regexp(tokens{1}, '^[^\s,]*\.?[^\s,]*$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidSpeciesName', 'Line %i in %s has an invalid species name: %s', lineNumber, files{iFile}, line)
+                assert(~isempty(regexp(tokens{1}, '^([^.]+\.)?[^.]+$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidSpeciesName', 'Line %i in %s has an invalid species name: %s', line_number, files{i_file}, line)
                 name = tokens{1};
                 
                 % Second token is value
                 if numel(tokens) >= 2
-                    assert(~isempty(regexp(tokens{2}, decimal_regex, 'once')), 'KroneckerBio:LoadModelMassAction:InvalidInputValue', 'Line %i in %s has an input with a value that is not a number: %s', lineNumber, files{iFile}, line)
+                    assert(~isempty(regexp(tokens{2}, decimal_regex, 'once')), 'KroneckerBio:LoadModelMassAction:InvalidInputValue', 'Line %i in %s has an input with a value that is not a number: %s', line_number, files{i_file}, line)
                     value = str2double(tokens{2});
                 else
                     value = 0;
@@ -175,16 +182,9 @@ for iFile = 1:nFiles
                 % Add Input
                 m = AddInput(m, name, compartment, value);
             elseif mode == 3
-                % Seeds
-                tokens = vec(regexp(line, ',|".*"|[^\s,]*','match'));
-                
-                % Strip quotes
-                for iTok = 1:numel(tokens)
-                    tokens{iTok} = regexp(tokens{iTok}, '[^"]*', 'match', 'once');
-                end
-                
+                %% Seeds
                 % Extract name
-                assert(~isempty(regexp(tokens{1}, '^[^\s,.]*$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidParameterName', 'Line %i in %s has an invalid seed name: %s', lineNumber, files{iFile}, line)
+                assert(~isempty(regexp(tokens{1}, '^[^.]+$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidParameterName', 'Line %i in %s has an invalid seed name: %s', line_number, files{i_file}, line)
                 name = tokens{1};
                 
                 % Second token is the number
@@ -193,111 +193,43 @@ for iFile = 1:nFiles
                 % Add seed
                 m = AddSeed(m, name, value);
             elseif mode == 4
-                % States
-                tokens = vec(regexp(line, '".*"|[^\s,]*','match'));
-                
-                % Strip inline comment; ignores #'s inside quotes
-                commentPos = find(~cellfun(@isempty, regexp(tokens, '^#')));
-                if ~isempty(commentPos)
-                    tokens = tokens(1:commentPos-1);
-                end
-                
-                % Strip quotes
-                for iTok = 1:numel(tokens)
-                    tokens{iTok} = regexp(tokens{iTok}, '[^"]*', 'match', 'once');
-                end
-                
+                %% States
                 % Extract name
-                assert(~isempty(regexp(tokens{1}, '^[^\s,]*\.?[^\s,]*$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidName', 'Line %i in %s has an invalid species name: %s', lineNumber, files{iFile}, line)
+                assert(~isempty(regexp(tokens{1}, '^([^.]+\.)?[^.]+$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidName', 'Line %i in %s has an invalid species name: %s', line_number, files{i_file}, line)
                 name = tokens{1};
-                tokens = tokens(2:end);
                 
                 % Process seeds
-                n_seeds = numel(tokens);
-                seeds = cell(n_seeds,2);
-                for i_seed = 1:n_seeds
-                    % Split between the equal sign
-                    elements = regexp(tokens{i_seed}, '=', 'split');
-                    assert(numel(elements) <= 2, 'KroneckerBio:LoadModelMassAction:InvalidExpression', 'Line %i in %s has more than one equal sign in an expression: %s', lineNumber, files{iFile}, line)
-                    
-                    if numel(elements) == 2
-                        % It is a seed and a modifier
-                        seeds(i_seed,:) = {elements{1}, str2double(elements{2})};
-                    elseif numel(elements) == 1 && ~isempty(regexp(tokens{1}, '^\d', 'once'))
-                        % It is a constitutive initial value
-                        seeds(i_seed,:) = {'',  eval(elements{1})};
-                    else
-                        % It is a single seed
-                        seeds(i_seed,:) = {elements{1}, 1};
-                    end
-                end
+                tokens = tokens(2:end);
+                seeds = extract_values(tokens);
                 
                 % Add State
                 m = AddState(m, name, compartment, seeds);
             elseif mode == 5
-                % Outputs
-                tokens = vec(regexp(line, ',|".*"|[^\s,]*','match'));
-                
-                % Strip quotes
-                for iTok = 1:numel(tokens)
-                    tokens{iTok} = regexp(tokens{iTok}, '[^"]*', 'match', 'once');
-                end
-                
+                %% Outputs
                 % Extract name
-                assert(~isempty(regexp(tokens{1}, '^[^\s,.]*$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidName', 'Line %i in %s has an invalid output name: %s', lineNumber, files{iFile}, line)
+                assert(~isempty(regexp(tokens{1}, '^[^.]+$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidName', 'Line %i in %s has an invalid output name: %s', line_number, files{i_file}, line)
                 name = tokens{1};
-                tokens = tokens(2:end);
                 
-                % Process seeds
-                n_expr = numel(tokens);
-                expressions = cell(n_expr,2);
-                for i_expr = 1:n_expr
-                    % Split between the equal sign
-                    elements = regexp(tokens{i_expr}, '=', 'split');
-                    assert(numel(elements) <= 2, 'KroneckerBio:LoadModelMassAction:InvalidExpression', 'Line %i in %s has more than one equal sign in an expression: %s', lineNumber, files{iFile}, line)
-                    
-                    if numel(elements) == 2
-                        % It is a expression and a modifier
-                        expressions(i_expr,:) = {elements{1}, str2double(elements{2})};
-                    elseif numel(elements) == 1 && ~isempty(regexp(tokens{1}, '^\d', 'once'))
-                        % It is a constitutive value
-                        expressions(i_expr,:) = {'',  eval(elements{1})};
-                    else
-                        % It is a single expression
-                        expressions(i_expr,:) = {elements{1}, 1};
-                    end
-                end
+                % Process outputs
+                tokens = tokens(2:end);
+                exprs = extract_values(tokens);
                 
                 % Add output
-                m = AddOutput(m, name, expressions);
+                m = AddOutput(m, name, exprs);
             elseif mode == 6
-                % Parameters
-                tokens = vec(regexp(line, ',|".*"|[^\s,]*','match'));
-                
-                % Strip quotes
-                for iTok = 1:numel(tokens)
-                    tokens{iTok} = regexp(tokens{iTok}, '[^"]*', 'match', 'once');
-                end
-                
+                %% Parameters
                 % Extract parameter name
-                assert(~isempty(regexp(tokens{1}, '^[^\s,.]*$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidName', 'Line %i in %s has an invalid parameter name: %s', lineNumber, files{iFile}, line)
+                assert(~isempty(regexp(tokens{1}, '^[^.]+$', 'once')), 'KroneckerBio:LoadModelMassAction:InvalidName', 'Line %i in %s has an invalid parameter name: %s', line_number, files{i_file}, line)
                 name = tokens{1};
                 
                 % Second token is value
-                assert(numel(tokens) >= 2, 'KroneckerBio:LoadModelMassAction:MissingParameterValue', 'Line %i in %s is missing its parameter value: %s', lineNumber, files{iFile}, line)
+                assert(numel(tokens) >= 2, 'KroneckerBio:LoadModelMassAction:MissingParameterValue', 'Line %i in %s is missing its parameter value: %s', line_number, files{i_file}, line)
                 value = eval(tokens{2});
                 
                 % Add parameter
                 m = AddParameter(m, name, value);
             elseif mode == 7
-                % Reactions
-                tokens = vec(regexp(line, ',|".*"|[^\s,]*','match'));
-                
-                % Strip quotes
-                for iTok = 1:numel(tokens)
-                    tokens{iTok} = regexp(tokens{iTok}, '[^"]*', 'match', 'once');
-                end
-                
+                %% Reactions
                 if ~strcmp(tokens{1}, ',')
                     % Add empty reverse parameter if not specified
                     if numel(tokens) < 6
@@ -308,7 +240,7 @@ for iFile = 1:nFiles
                     for i = 1:size(parameters,1)
                         % Split between the equal sign
                         elements = regexp(tokens{i+4}, '=', 'split');
-                        assert(numel(elements) <= 2, 'KroneckerBio:LoadModelMassAction:InvalidExpression', 'Line %i in %s has more than one equal sign in an expression: %s', lineNumber, files{iFile}, line)
+                        assert(numel(elements) <= 2, 'KroneckerBio:LoadModelMassAction:InvalidExpression', 'Line %i in %s has more than one equal sign in an expression: %s', line_number, files{i_file}, line)
                         
                         if strcmp(elements{1}, '0')
                             % It is an empty reaction
@@ -327,12 +259,14 @@ for iFile = 1:nFiles
                     products = tokens(3:4);
                     products = products(~strcmp(products, '0'));
                     
+                    names = tokens(7:end);
+                    
                     % This is a normal line
-                    m = AddReaction(m, tokens(7:end), reactants, products, parameters(1,:), parameters(2,:));
+                    m = AddReaction(m, names, reactants, products, parameters(1,:), parameters(2,:));
                 else
                     % Split between the equal sign
                     parameter = regexp(tokens{end}, '=', 'split');
-                    assert(numel(parameter) <= 2, 'KroneckerBio:LoadModelMassAction:InvalidExpression', 'Line %i in %s has more than one equal sign in an expression: %s', lineNumber, files{iFile}, line)
+                    assert(numel(parameter) <= 2, 'KroneckerBio:LoadModelMassAction:InvalidExpression', 'Line %i in %s has more than one equal sign in an expression: %s', line_number, files{i_file}, line)
                     
                     if numel(parameter) == 2
                         % It is a parameter and a modifier
@@ -346,12 +280,12 @@ for iFile = 1:nFiles
                     reactants = reactants(~strcmp(reactants, '0'));
                     products = tokens(4:end-1);
                     products = products(~strcmp(products, '0'));
-
+                    
                     % This is the special syntax for a multi-product line
                     m = AddReaction(m, [], reactants, products, parameter);
                 end
             else
-                error('KroneckerBio:LoadModelMassAction:SectionNotSpecified', 'Line %i in %s occurs before any section header: %s', lineNumber, files{iFile}, line)
+                error('KroneckerBio:LoadModelMassAction:SectionNotSpecified', 'Line %i in %s occurs before any section header: %s', line_number, files{i_file}, line)
             end
         end
     end
@@ -362,3 +296,35 @@ end
 
 %% Finalize Model
 m = FinalizeModel(m);
+
+%% Helper function
+    function exprs = extract_values(tokens)
+        % Extract components of linear combination in cell matrix form
+        %
+        % Inputs
+        %   tokens [ 1 x nTokens cell vector of strings ]
+        %       Input tokens to extract
+        %
+        % Output:
+        %   exprs [ nExpr x 2 cell matrix of (string,double) rows ]
+        %       Output cell matrix used in Add* functions
+        n_expr = numel(tokens);
+        exprs = cell(n_expr,2);
+        for i_expr = 1:n_expr
+            % Split between the equal sign
+            elements = regexp(tokens{i_expr}, '=', 'split');
+            assert(numel(elements) <= 2, 'KroneckerBio:LoadModelMassAction:InvalidExpression', 'Line %i in %s has more than one equal sign in an expression: %s', line_number, files{i_file}, line)
+            
+            if numel(elements) == 2
+                % It is a expression and a modifier
+                exprs(i_expr,:) = {elements{1}, str2double(elements{2})};
+            elseif numel(elements) == 1 && ~isempty(regexp(elements{1}, '^\d', 'once'))
+                % It is a constitutive value
+                exprs(i_expr,:) = {'',  str2double(elements{1})};
+            else
+                % It is a single expression
+                exprs(i_expr,:) = {elements{1}, 1};
+            end
+        end
+    end
+end

--- a/Source/private/fixReactionName.m
+++ b/Source/private/fixReactionName.m
@@ -23,13 +23,14 @@ if ischar(name)
 end
 
 if iscell(name)
-    if numel(name)
-        name1 = name{1};
-        name2 = name{1};
-    elseif numel(name)
-        name1 = name{1};
-        name2 = name{2};
-    else
-        error('KroneckerBio:fixReactionName:TooManyNames', 'The name of reaction %s was given as a cell array, but there are more than two entries, the maximum', name)
+    switch numel(name)
+        case 1
+            name1 = name{1};
+            name2 = name{1};
+        case 2
+            name1 = name{1};
+            name2 = name{2};
+        otherwise
+            error('KroneckerBio:fixReactionName:TooManyNames', 'The name of reaction %s was given as a cell array, but there are more than two entries, the maximum', name{1})
     end
 end

--- a/Testing/Equilibrium.txt
+++ b/Testing/Equilibrium.txt
@@ -19,4 +19,4 @@ kon  5
 koff 3
 
 % Reactions
-a b c 0 kon koff On,Off
+a b c 0 kon koff On Off

--- a/Testing/UT02_LoadingModels.m
+++ b/Testing/UT02_LoadingModels.m
@@ -5,14 +5,34 @@ if nargout < 1
 end
 end
 
+% Make sure these tests are updated as the example files change
 function testEquilibriumLoading(a)
 m = LoadModelMassAction('Equilibrium.txt');
 a.verifyEqual(m.Name, 'Equilibrium');
+a.verifyEqual({m.Compartments.Name}, {'v'});
+a.verifyEqual({m.Parameters.Name}, {'kon','koff'});
+a.verifyEqual({m.States.Name}, {'a','b','c'});
+a.verifyEqual({m.Reactions.Name}, {'On','Off'});
+a.verifyEqual({m.Outputs.Name}, {'A','B','C'});
+verifyDerivatives(a, m);
 end
 
 function testSimpleLoading(a)
 m = LoadModelMassAction('Simple.txt');
 a.verifyEqual(m.Name, 'Simple')
+verifyDerivatives(a, m);
+end
+
+function testTestingLoading(a)
+m = LoadModelMassAction('../Tutorial/Testing.txt');
+a.verifyEqual(m.Name, 'Testing')
+a.verifyEqual({m.Compartments.Name}, {'v1','v2','v3','v4'});
+a.verifyEqual({m.Parameters.Name}, {'k1','k2'});
+a.verifyEqual({m.Seeds.Name}, {'s1','s2'});
+a.verifyEqual({m.Inputs.Name}, {'u4','u5'});
+a.verifyEqual({m.States.Name}, {'x1','x2','x3','x4','x5','x6','x7','x8'});
+a.verifyEqual({m.Reactions.Name}, {'r1','r2','','','r35','r5','r6','',''});
+a.verifyEqual({m.Outputs.Name}, {'y1','y2','y3','y4','y5'});
 verifyDerivatives(a, m);
 end
 

--- a/Tutorial/Testing.txt
+++ b/Tutorial/Testing.txt
@@ -28,9 +28,13 @@
 
 # Lines of the compartment section follow this format:
 #Name  Dim  Volume
-v1     3    1e-6
+v1     3    1e-6 # comments that appear after a '#' are ignored
 v2     2    1.2e-4
 v3     1    1e-3
+  
+# Compartment volumes can be a constant term plus a linear combination of
+#   states and inputs
+v4     3    1 x1=1.2 u1=1.3
 
 # As it stands right now, names can be arbitrary strings. You should avoid 
 # starting the name with
@@ -64,11 +68,20 @@ x2
 x3  s1
 x4  s2
 
+# The initial amount can be a linear combination of seed parameters. Seeds are
+# separated by spaces, with default coefficient 1
+x5  s1 s2
+
+# Non-unity coefficients for seeds can be set with an equals sign. Make sure
+# there are no spaces between the seed and coefficient. Also, a constant term
+# can be added.
+x6  s1=1.4 s2=1.5 1.6
+
 % States v2
-x6 
+x7 
 
 % States v3
-x7 1
+x8 1
 
 # The Inputs header (starting with a "%") is the same as the Staes header
 # because inputs are assigned to compartments just like states
@@ -83,7 +96,6 @@ x7 1
 u4     2
 u5     5
 
-
 # Output headers do not take any additional parameters
 % Outputs
 
@@ -92,7 +104,7 @@ u5     5
 y1    x1=1
 
 # Value is a set of species names combined with equal signs and 
-# numbers, seperated by commas. The default number is 1, so the following 
+# numbers, seperated by spaces. The default number is 1, so the following 
 # is identical to the previous line.
 # y1 x1
 
@@ -100,15 +112,18 @@ y1    x1=1
 y2 x1 x2
 y3 x4 u5
 
-# Values do not have to be integers
+# Values don't have to be 1
 y4 x3=1.2
+
+# Multiple non-unity values are allowed. Also, a constant term can be added.
+y5 x1=1.5 x2=2.5 3.5 # this is a comment
 
 # The Parameters section is the simplest section. There are no additional
 # parameters in the header.
 % Parameters
 #Name Value
 k1    1
-k2 1.3e-4
+k2    1.3e-4
 
 # The Seeds section is just as simple as the Parameters. There are no additional
 # parameters in the header.


### PR DESCRIPTION
In `LoadModelMassAction`, when parsing reaction names, the last few tokens are simply passed into `AddReaction`. In the `Equilibrium.txt` test model, the reaction names are separated by a comma, which is passed in as one of these names. The parser has been fixed to properly take the actual names.

Question: Is the last part of the line `a_ b c 0 kon koff On,Off` in `Equilibrium.txt` supposed to read that way? The tokenizer regex in `LoadModelMassAction` thinks the names are `{'On', ',', 'Off'}`. My fix takes care of this case plus `a_ b c 0 kon koff On Off`.

In `fixReactionName`, the number of names in a cell array of `name` isn't properly parsed. This manifested as the reverse reaction name never being set. The cases have been fixed.

Since rxn names are only used for user organization, it doesn't change any results, but this is definitely a bug.