### PR TITLE
Fixed adjoint sensitivites hanging on some steady state simulations

### DIFF
--- a/Source/private/computeObjSensAdj.m
+++ b/Source/private/computeObjSensAdj.m
@@ -60,7 +60,7 @@ for i_con = 1:n_con
     
     % * Integrate to steady-state
     if con(i_con).SteadyState
-        ssSol = integrateSteadystateSys(m, con(i_con), opts_i);
+        ssSol = steadystateSysComp(m, con(i_con), opts_i);
         ic = ssSol.ye(:,end);
     else
         order = 0;

--- a/Source/private/steadystateSys.m
+++ b/Source/private/steadystateSys.m
@@ -18,7 +18,7 @@ if ~atSteadyState
     % Integrate f over time
     %     accumulateOdeFwdSimp(der, jac, t0, tF, ic, discontinuities, t_get, nonnegative, RelTol, AbsTol, delta, events, is_finished)
     sol = accumulateOdeFwdSimp(der, jac, 0, inf, ic, con.private.BasalDiscontinuities, 0, 1:nx, opts.RelTol, opts.AbsTol(1:nx), [], eve, @(cum_sol)true);
-
+    
     % Return steady-state value
     ic = sol.ye;
 end

--- a/Testing/UT08_Gradient.m
+++ b/Testing/UT08_Gradient.m
@@ -26,6 +26,21 @@ simpleopts.steadyState = true;
 verifyGradient(a, m, con, obj, opts)
 end
 
+function testObjectiveGradientSimpleSteadyStateStartingAtSteadyState(a)
+simpleopts.steadyState = true;
+[m, con, obj, opts] = simple_model(simpleopts);
+
+% Set k, q, and s to zero so that model is inactive in the basal
+% simulation and the starting state is a steady state
+newk = repmat(1e-9, size(m.k));
+m = m.Update(newk);
+newq = repmat(1e-9, size(con.q));
+news = repmat(1e-9, size(con.s));
+con = con.Update(news, newq, con.h);
+
+verifyGradient(a, m, con, obj, opts)
+end
+
 function testObjectiveGradientSimple(a)
 [m, con, obj, opts] = simple_model();
 

--- a/Testing/simple_model.m
+++ b/Testing/simple_model.m
@@ -248,6 +248,8 @@ opts.AbsTol = GoodAbsTol(m, con, sd, opts);
                 val = [h(1); 0; 0];
             elseif t <= border3
                 val = [h(2)*h(3)+h(3); 0; 0];
+            else
+                val = zeros(nh,1);
             end
         else
             val = zeros(nh, 1);


### PR DESCRIPTION
Added test to UT08_Gradient for the case where the initial conditions are a steady state. Renamed integrateSteadystateSys to steadystateSysComp to be more descriptive and consistent with other functions' naming. Added dose values for t>border3 to simple_model so that simulations longer than border3 don't error.