### PR TITLE
Duplicate reaction check for mass action models now compares rate terms

### DIFF
--- a/Source/finalizeModelMassActionAmount.m
+++ b/Source/finalizeModelMassActionAmount.m
@@ -460,6 +460,8 @@ for ir = 1:nr
         % Add more room in vector if necessary
         SEntries = make_room(SEntries, nSEntries);
         SValues  = make_room(SValues, nSEntries);
+        SuEntries = make_room(SuEntries, nSuEntries);
+        SuValues = make_room(SuValues, nSuEntries);
         
         % Subtract reactant
         SEntries(nSEntries-nAdd+1,1) = reactants(1);
@@ -510,6 +512,8 @@ for ir = 1:nr
         % Add more room in vector if necessary
         SEntries = make_room(SEntries, nSEntries);
         SValues  = make_room(SValues, nSEntries);
+        SuEntries = make_room(SuEntries, nSuEntries);
+        SuValues = make_room(SuValues, nSuEntries);
         
         % Subtract reactant 1
         SEntries(nSEntries-nAdd+1,1) = reactants(1);
@@ -574,6 +578,8 @@ for ir = 1:nr
             % Add more room in vector if necessary
             SEntries = make_room(SEntries, nSEntries);
             SValues  = make_room(SValues, nSEntries);
+            SuEntries = make_room(SuEntries, nSuEntries);
+            SuValues = make_room(SuValues, nSuEntries);
             
             % Subtract reactant 1
             SuEntries(nSuEntries-nuAdd+1,1) = reactants(1);
@@ -595,7 +601,7 @@ for ir = 1:nr
                     SEntries(Srow,2) = ir;
                     SValues(Srow)    = 1;
                 else
-                    Srow = nSuEntries-nuAdd+inputs_added_so_far(i_prod);
+                    Srow = nSuEntries-nuAdd+1+inputs_added_so_far(i_prod);
                     SuEntries(Srow,1) = products(i_prod);
                     SuEntries(Srow,2) = ir;
                     SuValues(Srow)    = 1;
@@ -624,6 +630,8 @@ for ir = 1:nr
             % Add more room in vector if necessary
             SEntries = make_room(SEntries, nSEntries);
             SValues  = make_room(SValues, nSEntries);
+            SuEntries = make_room(SuEntries, nSuEntries);
+            SuValues = make_room(SuValues, nSuEntries);
             
             % Subtract reactant 1
             SEntries(nSEntries-nAdd+1,1) = reactants(1);
@@ -645,7 +653,7 @@ for ir = 1:nr
                     SEntries(Srow,2) = ir;
                     SValues(Srow)    = 1;
                 else
-                    Srow = nSuEntries-nuAdd+inputs_added_so_far(i_prod);
+                    Srow = nSuEntries-nuAdd+1+inputs_added_so_far(i_prod);
                     SuEntries(Srow,1) = products(i_prod);
                     SuEntries(Srow,2) = ir;
                     SuValues(Srow)    = 1;
@@ -681,6 +689,8 @@ for ir = 1:nr
         % Add more room in vector if necessary
         SEntries = make_room(SEntries, nSEntries);
         SValues  = make_room(SValues, nSEntries);
+        SuEntries = make_room(SuEntries, nSuEntries);
+        SuValues = make_room(SuValues, nSuEntries);
         
         % Subtract reactant 1
         SuEntries(nSuEntries-nuAdd+1,1) = reactants(1);
@@ -702,7 +712,7 @@ for ir = 1:nr
                 SEntries(Srow,2) = ir;
                 SValues(Srow)    = 1;
             else
-                Srow = nSuEntries-nuAdd+inputs_added_so_far(i_prod);
+                Srow = nSuEntries-nuAdd+2+inputs_added_so_far(i_prod);
                 SuEntries(Srow,1) = products(i_prod);
                 SuEntries(Srow,2) = ir;
                 SuValues(Srow)    = 1;
@@ -731,6 +741,8 @@ for ir = 1:nr
         % Add more room in vector if necessary
         SEntries = make_room(SEntries, nSEntries);
         SValues  = make_room(SValues, nSEntries);
+        SuEntries = make_room(SuEntries, nSuEntries);
+        SuValues = make_room(SuValues, nSuEntries);
         
         % Subtract reactant 1
         SuEntries(nSuEntries-nuAdd+1,1) = reactants(1);
@@ -747,7 +759,7 @@ for ir = 1:nr
                 SEntries(Srow,2) = ir;
                 SValues(Srow)    = 1;
             else
-                Srow = nSuEntries-nuAdd+inputs_added_so_far(i_prod);
+                Srow = nSuEntries-nuAdd+1+inputs_added_so_far(i_prod);
                 SuEntries(Srow,1) = products(i_prod);
                 SuEntries(Srow,2) = ir;
                 SuValues(Srow)    = 1;
@@ -776,6 +788,8 @@ for ir = 1:nr
         % Add more room in vector if necessary
         SEntries = make_room(SEntries, nSEntries);
         SValues  = make_room(SValues, nSEntries);
+        SuEntries = make_room(SuEntries, nSuEntries);
+        SuValues = make_room(SuValues, nSuEntries);
         
         % Add products
         states_added_so_far = cumsum(productsAreStates);
@@ -893,7 +907,8 @@ D5UsedColumns = vec(unique(D5UsedColumns));
 i_reaction_name = sparse(i_reaction_name - 1);
 
 % Assemble reactions into one big matrix
-reaction_matrix = [sparse(m.krInd), m.S.', Su.', i_reaction_name];
+reaction_matrix = [sparse(m.krInd), m.S.', Su.', i_reaction_name, ...
+    [m.D1 m.D2 m.D3 m.D4 m.D5 m.D6]~=0];
 
 % All rows that already appeared elsewhere
 [~, i_unique_reactions] = unique(reaction_matrix, 'rows');

--- a/Testing/UT01a_BuildingModelsMassAction.m
+++ b/Testing/UT01a_BuildingModelsMassAction.m
@@ -135,6 +135,68 @@ test = AddReaction(m, 'r1', 'x1', {}, 'k');
 a.verifyWarning(@()FinalizeModel(test), 'KroneckerBio:FinalizeModel:RepeatReactions'); % note: throws warning and ignores
 end
 
+function testReactionTypes(a)
+m = InitializeModelMassActionAmount();
+m = AddCompartment(m, 'v1', 3, 1);
+m = AddCompartment(m, 'v2', 2, 1);
+m = AddParameter(m, 'k', 4);
+m = AddState(m, 'x1', 'v1', 1);
+m = AddInput(m, 'u1', 'v1', 1);
+m = AddState(m, 'x2', 'v2', 1);
+m = AddInput(m, 'u2', 'v2', 1);
+% D1
+m = AddReaction(m, 'r1', {'x1'}, {}, 'k');
+m = AddReaction(m, 'r1', {'x1'}, {'x1'}, 'k');
+m = AddReaction(m, 'r1', {'x1'}, {'u1'}, 'k');
+m = AddReaction(m, 'r1', {'x1'}, {'x1','x1'}, 'k');
+m = AddReaction(m, 'r1', {'x1'}, {'x1','u1'}, 'k');
+m = AddReaction(m, 'r1', {'x1'}, {'u1','u1'}, 'k');
+% D2
+m = AddReaction(m, 'r1', {'x1','x1'}, {}, 'k');
+m = AddReaction(m, 'r1', {'x1','x1'}, {'x1'}, 'k');
+m = AddReaction(m, 'r1', {'x1','x1'}, {'u1'}, 'k');
+m = AddReaction(m, 'r1', {'x1','x1'}, {'x1','x1'}, 'k');
+m = AddReaction(m, 'r1', {'x1','x1'}, {'x1','u1'}, 'k');
+m = AddReaction(m, 'r1', {'x1','x1'}, {'u1','u1'}, 'k');
+% D3
+m = AddReaction(m, 'r1', {'u1','x2'}, {}, 'k');
+m = AddReaction(m, 'r1', {'u1','x2'}, {'x1'}, 'k');
+m = AddReaction(m, 'r1', {'u1','x2'}, {'u1'}, 'k');
+m = AddReaction(m, 'r1', {'u1','x2'}, {'x1','x1'}, 'k');
+m = AddReaction(m, 'r1', {'u1','x2'}, {'x1','u1'}, 'k');
+m = AddReaction(m, 'r1', {'u1','x2'}, {'u1','u1'}, 'k');
+% D4
+m = AddReaction(m, 'r1', {'x1','u2'}, {}, 'k');
+m = AddReaction(m, 'r1', {'x1','u2'}, {'x1'}, 'k');
+m = AddReaction(m, 'r1', {'x1','u2'}, {'u1'}, 'k');
+m = AddReaction(m, 'r1', {'x1','u2'}, {'x1','x1'}, 'k');
+m = AddReaction(m, 'r1', {'x1','u2'}, {'x1','u1'}, 'k');
+m = AddReaction(m, 'r1', {'x1','u2'}, {'u1','u1'}, 'k');
+% D5
+m = AddReaction(m, 'r1', {'u1','u1'}, {}, 'k');
+m = AddReaction(m, 'r1', {'u1','u1'}, {'x1'}, 'k');
+m = AddReaction(m, 'r1', {'u1','u1'}, {'u1'}, 'k');
+m = AddReaction(m, 'r1', {'u1','u1'}, {'x1','x1'}, 'k');
+m = AddReaction(m, 'r1', {'u1','u1'}, {'x1','u1'}, 'k');
+m = AddReaction(m, 'r1', {'u1','u1'}, {'u1','u1'}, 'k');
+% D6
+m = AddReaction(m, 'r1', {'u1'}, {}, 'k');
+m = AddReaction(m, 'r1', {'u1'}, {'x1'}, 'k');
+m = AddReaction(m, 'r1', {'u1'}, {'u1'}, 'k');
+m = AddReaction(m, 'r1', {'u1'}, {'x1','x1'}, 'k');
+m = AddReaction(m, 'r1', {'u1'}, {'x1','u1'}, 'k');
+m = AddReaction(m, 'r1', {'u1'}, {'u1','u1'}, 'k');
+% d
+m = AddReaction(m, 'r1', {}, {}, 'k');
+m = AddReaction(m, 'r1', {}, {'x1'}, 'k');
+m = AddReaction(m, 'r1', {}, {'u1'}, 'k');
+m = AddReaction(m, 'r1', {}, {'x1','x1'}, 'k');
+m = AddReaction(m, 'r1', {}, {'x1','u1'}, 'k');
+m = AddReaction(m, 'r1', {}, {'u1','u1'}, 'k');
+
+m = FinalizeModel(m);
+end
+
 function testRepeatedReactionsInputs(a)
 m = InitializeModelMassActionAmount();
 m = AddCompartment(m, 'v1', 3, 1);
@@ -144,6 +206,20 @@ m = AddInput(m, 'u1', 'v1', 1);
 m = AddInput(m, 'u2', 'v1', 1);
 m = AddReaction(m, 'r1', {'x1', 'u1'}, {}, 'k');
 m = AddReaction(m, 'r1', {'x1', 'u2'}, {}, 'k');
+
+a.verifyWarningFree(@()FinalizeModel(m))
+end
+
+function testRepeatedReactionsRates(a)
+m = InitializeModelMassActionAmount();
+m = AddCompartment(m, 'v1', 3, 1);
+m = AddParameter(m, 'k', 4);
+m = AddState(m, 'x1', 'v1', 1);
+m = AddState(m, 'x2', 'v1', 1);
+m = AddInput(m, 'u1', 'v1', 1);
+m = AddReaction(m, 'r1', {'x1'}, {}, 'k');
+m = AddReaction(m, 'r1', {'x1', 'x2'}, {'x2'}, 'k');
+m = AddReaction(m, 'r1', {'x1', 'u1'}, {'u1'}, 'k');
 
 a.verifyWarningFree(@()FinalizeModel(m))
 end

--- a/Testing/mass_action_build_speed.m
+++ b/Testing/mass_action_build_speed.m
@@ -1,0 +1,51 @@
+function build_times = mass_action_build_speed()
+% Builds a mass action model with various numbers of reactions to determine
+% how the build speed scales with model size.
+
+n_reactions = [3 10 30 100 300];
+build_times = nan(numel(n_reactions), 1);
+for i = 1:numel(n_reactions)
+    fprintf('%0g reactions...', n_reactions(i))
+    
+    tic;
+    m = InitializeModelMassActionAmount('build speed');
+    for j = 1:n_reactions(i)
+        % Add compartment
+        comp_j = sprintf('v%d',j);
+        m = AddCompartment(m, comp_j, 3, rand);
+        
+        % Add a state with a seed
+        state_j = sprintf('x%d',j);
+        seed_j = [state_j '_0'];
+        m = AddSeed(m, seed_j, rand);
+        m = AddState(m, state_j, comp_j, seed_j);
+        
+        % Add a parameter
+        param_j = sprintf('k%d',j);
+        m = AddParameter(m, param_j, rand);
+        
+        % Add an input
+        input_j = sprintf('u%d',j);
+        m = AddInput(m, input_j, comp_j, rand);
+        
+        % Add a reaction
+        reaction_j = sprintf('r%d',j);
+        % Randomly select zero, one, or two reactants and products from the
+        % new states and inputs
+        choices = {state_j, input_j, ''};
+        reactants = choices(randi(3,[1,2]));
+        reactants = reactants(~cellfun(@isempty, reactants));
+        products = choices(randi(3,[1,2]));
+        products = products(~cellfun(@isempty, products));
+        m = AddReaction(m, reaction_j, reactants, products, param_j);
+        
+        % Add an output
+        output_j = sprintf('y%d',j);
+        m = AddOutput(m, output_j, {state_j rand; input_j rand});
+    end
+    m = FinalizeModel(m);
+    build_times(i) = toc;
+    fprintf('done after %0g seconds.\n', build_times(i))
+end
+
+end


### PR DESCRIPTION
Also fixed errors thrown when inputs are set as products.
Also added tests to test the duplicate reaction checker.
Also added mass_action_build_speed.m to test build speeds.

The duplicate reaction check fix was actually really simple and involves a single line code change. I also found a few other bugs involving inputs as products in reactions, so I fixed those and added tests to check the issues. All tests passed on my machine.

I also wrote a function that generates mass action models of various sizes and times how long it takes to build the models to make sure my fix isn't causing a major performance hit to model building. Profiling this code, spermute132 called on the higher-order matrices dominates the build time for larger models, and the duplicate check code is a miniscule fraction of the build time.