### PR TITLE
Model functions now support symbolics

### DIFF
--- a/External/mtimestall.m
+++ b/External/mtimestall.m
@@ -3,7 +3,7 @@ function C = mtimestall(A, B)
 % tall, yet very sparse. This is a workaround that avoids using mtimes and
 % instead uses scalar multiplication.
 
-if nnz(A) < size(A,1)
+if nnz(A) < size(A,1) && ~(isa(A,'sym') || isa(B,'sym'))
     % Allocate memory for output
     C = sparse([], [], [], size(A,1), size(B,2), nnz(A)*min(nnz(B),size(B,2)));
     

--- a/Source/finalizeModelAnalytic.m
+++ b/Source/finalizeModelAnalytic.m
@@ -1259,7 +1259,7 @@ end
 if isempty(dens)
     sparsestr = {'[' ']'};
 else
-    sparsestr = {'sparse(' ')'};
+    sparsestr = {'sym_sparse(' ')'};
 end
 
 if use_inf2big
@@ -1303,7 +1303,11 @@ end
 
 function val = vectorize_y(y, t, x, u, k, ny)
     nt = numel(t);
-    val = zeros(ny,nt);
+    if isa(t, 'sym') || isa(x, 'sym') || isa(u, 'sym') || isa(k, 'sym')
+        val = zeros(ny,nt,'sym');
+    else
+        val = zeros(ny,nt);
+    end
     if isempty(x)
         x = zeros(0,nt);
     end
@@ -1351,3 +1355,14 @@ for i = 1:n_new
     end
 end
 end
+
+% function S = sparse(varargin)
+% % Redefined sparse() function that constructs full matrices using
+% % the sparse syntax if input arguments are symbolic.
+% S = sym_sparse(varargin{:});
+% end
+
+% function c = bsxfun(varargin)
+% % Redefined bsxfun() that works with symbolic arrays.
+% c = sym_bsxfun(varargin{:});
+% end

--- a/Source/finalizeModelMassActionAmount.m
+++ b/Source/finalizeModelMassActionAmount.m
@@ -1100,7 +1100,7 @@ m.r = rHidden(m.D1, m.D2, m.D3, m.D4, m.D5, m.D6, m.d, m.v, D2UsedColumns, D2Use
 
 m.drdx = drdxHidden(m.D1, m.D2, m.D3, m.D4, m.D5, m.v, m.dvdx, D2UsedColumns, D2UsedSpecies1, D2UsedSpecies2, D3UsedColumns, D3UsedSpecies1, D3UsedSpecies2, D4UsedColumns, D4UsedSpecies1, D4UsedSpecies2, D5UsedColumns, D5UsedSpecies1, D5UsedSpecies2, m.vxInd, m.vuInd);
 m.drdu = drduHidden(m.D2, m.D3, m.D4, m.D5, m.D6, m.v, m.dvdu, D2UsedColumns, D2UsedSpecies1, D2UsedSpecies2, D3UsedColumns, D3UsedSpecies1, D3UsedSpecies2, D4UsedColumns, D4UsedSpecies1, D4UsedSpecies2, D5UsedColumns, D5UsedSpecies1, D5UsedSpecies2, m.vxInd, m.vuInd);
-m.drdk = drdkHidden(m.dD1dk_rk_x, m.dD2dk_rk_xx, m.dD3dk_rk_ux, m.dD4dk_rk_xu, m.dD5dk_rk_uu, m.dD6dk_rk_u, m.dadk, m.v, D2UsedColumns, D2UsedSpecies1, D2UsedSpecies2, D3UsedColumns, D3UsedSpecies1, D3UsedSpecies2, D4UsedColumns, D4UsedSpecies1, D4UsedSpecies2, D5UsedColumns, D5UsedSpecies1, D5UsedSpecies2, m.vxInd, m.vuInd);
+m.drdk = drdkHidden(m.dD1dk_rk_x, m.dD2dk_rk_xx, m.dD3dk_rk_ux, m.dD4dk_rk_xu, m.dD5dk_rk_uu, m.dD6dk_rk_u, m.dddk, m.v, D2UsedColumns, D2UsedSpecies1, D2UsedSpecies2, D3UsedColumns, D3UsedSpecies1, D3UsedSpecies2, D4UsedColumns, D4UsedSpecies1, D4UsedSpecies2, D5UsedColumns, D5UsedSpecies1, D5UsedSpecies2, m.vxInd, m.vuInd);
 
 m.d2rdx2  = d2rdx2Hidden(m.D2, m.D3, m.D4, m.D5, m.v, m.dvdx, m.d2vdx2, D2UsedColumns, D2UsedSpecies1, D2UsedSpecies2, D3UsedColumns, D3UsedSpecies1, D3UsedSpecies2, D4UsedColumns, D4UsedSpecies1, D4UsedSpecies2, D5UsedColumns, D5UsedSpecies1, D5UsedSpecies2, m.vxInd, m.vuInd);
 m.d2rdu2  = d2rdu2Hidden(m.D2, m.D3, m.D4, m.D5, m.v, m.dvdu, m.d2vdu2, D2UsedColumns, D2UsedSpecies1, D2UsedSpecies2, D3UsedColumns, D3UsedSpecies1, D3UsedSpecies2, D4UsedColumns, D4UsedSpecies1, D4UsedSpecies2, D5UsedColumns, D5UsedSpecies1, D5UsedSpecies2, m.vxInd, m.vuInd);
@@ -2602,4 +2602,15 @@ if needed > current
     addlength = max(current, needed-current);
     array = [array; zeros(addlength, size(array,2))];
 end
+end
+
+function S = sparse(varargin)
+% Redefined sparse() function that constructs full matrices using
+% the sparse syntax if input arguments are symbolic.
+S = sym_sparse(varargin{:});
+end
+
+function c = bsxfun(varargin)
+% Redefined bsxfun() that works with symbolic arrays.
+c = sym_bsxfun(varargin{:});
 end

--- a/Source/sym_bsxfun.m
+++ b/Source/sym_bsxfun.m
@@ -1,0 +1,19 @@
+function c = sym_bsxfun(func,a,b)
+
+if isa(a,'sym') || isa(b,'sym')
+    as = size(a);
+    bs = size(b);
+    a_repmat = ones(size(as));
+    a_repmat(as == 1) = bs(as == 1);
+    b_repmat = ones(size(bs));
+    b_repmat(bs == 1) = as(bs == 1);
+    
+    a = repmat(a, a_repmat);
+    b = repmat(b, b_repmat);
+    
+    c = func(a,b);
+else
+    c = bsxfun(func,a,b);
+end
+
+end

--- a/Source/sym_sparse.m
+++ b/Source/sym_sparse.m
@@ -1,0 +1,75 @@
+function S = sym_sparse(varargin)
+% Redefined sparse() function that constructs full matrices using the
+% sparse syntax if input arguments are symbolic.  Note that this function
+% needs to be accessible on the path (i.e., not in the private folder) for
+% analytic model function handles to be able to find it.
+
+switch nargin
+    case 1
+        % One input argument normally converts to sparse matrix. Here, just
+        % return the input if it is symbolic, and convert to sparse
+        % otherwise.
+        if isa(varargin{1}, 'sym')
+            S = varargin{1};
+        else
+            S = builtin('sparse', varargin{:});
+        end
+    case 2
+        % Two input arguments initializes an empty sparse matrix.
+        % Here, initialize with zeros.
+        S = builtin('sparse', varargin{:});
+    case 3
+        % Three input arguments i,j,v generates a matrix
+        % S(i(k),j(k)) = v(k). If v is symbolic, create a full symbolic
+        % matrix. Otherwise just call sparse.
+        [i,j,v] = deal(varargin{:});
+        if isa(v,'sym')
+            imax = max(i(:));
+            jmax = max(j(:));
+            S = zeros(imax, jmax, 'like', v);
+            for k = 1:numel(i)
+                S(i(k),j(k)) = S(i(k),j(k)) + v(k);
+            end
+        else
+            S = builtin('sparse', varargin{:});
+        end
+    case 5
+        % Five input arguments i,j,v,m,n generates a matrix
+        % S(i(k),j(k)) = v(k), with S of size m-by-n. If v is symbolic,
+        % create a full symbolic matrix. Otherwise just call sparse.
+        [i,j,v,m,n] = deal(varargin{:});
+        if isempty(i) || isempty(j)
+            % If no nonzero elements are provided, just initialize an empty
+            % S of the same type as v
+            if isa(v, 'sym')
+                S = zeros(m, n, 'like', v);
+            else
+                S = sparse(varargin{:});
+            end
+        elseif isa(v, 'sym')
+            imax = max(i(:));
+            jmax = max(j(:));
+            assert(imax <= m, 'Index exceeds array bounds.')
+            assert(jmax <= n, 'Index exceeds array bounds.')
+            S = zeros(m, n, 'like', v);
+            for k = 1:numel(i)
+                S(i(k),j(k)) = S(i(k),j(k)) + v(k);
+            end
+        else
+            S = builtin('sparse', varargin{:});
+        end
+    case 6
+        % Six input arguments is the same as 5, but allocates space for
+        % more nonzero elements, which has no use for full matrices.
+        % Just use the code for five input arguments if symbolic.
+        [i,j,v,m,n,~] = deal(varargin{:});
+        if isa(v, 'sym')
+            S = sparse(i,j,v,m,n);
+        else
+            S = builtin('sparse', varargin{:});
+        end
+    otherwise
+        error('Unsupported number of input arguments.')
+end
+
+end


### PR DESCRIPTION
I locally redefined the sparse() function in
finalizeModelMassActionAmount and finalizeModelAnalytic such that
sparse() now creates a full symbolic matrix if input arguments are
symbolic. I also redefined bsxfun() in finalizeModelAnalytic. These
changes allows easy conversion of the model ODE RHS into a 
symbolic expression by passing symbolic parameters, states, and inputs into
the model functions.