### PR TITLE
Change to steady state method: iterative integration

### DIFF
--- a/Source/experimentSteadyState.m
+++ b/Source/experimentSteadyState.m
@@ -24,10 +24,11 @@ function con = experimentSteadyState(m, s, basal_input, inp, dos, time_scale, na
 %       Default = doseZero(m)
 %       The definition of the dose amounts and schedule
 %   time_scale: [ nonnegative scalar ]
-%       Default = 10
+%       Default = 100*24*60*60
 %       The typical time scale for an observation. The steady state is
-%       determined to be reached when the states are expected to change
-%       less than the tolerance over this time scale.
+%       determined to be reached when the states are observed to change
+%       less than the tolerance over this time scale. The default is 
+%       100*24*60*60, which is 100 days if the model time unit is seconds.
 %   name: [ string ]
 %       Default = ''
 %       An arbitrary name for the experiment
@@ -61,7 +62,7 @@ if nargin < 7
 end
 
 if isempty(time_scale)
-    time_scale = 10;
+    time_scale = 100*24*60*60; % 100 days, if units are seconds
 end
 if isempty(s)
     s = m.s;

--- a/Source/private/iterate_steady_state.m
+++ b/Source/private/iterate_steady_state.m
@@ -1,0 +1,35 @@
+function y_ss = iterate_steady_state(der, jac, ic, nx, abstol, reltol, basal_discontinuities, timescale)
+
+% Set up times for first simulation
+t0 = 0;
+tF = t0 + timescale;
+
+% Ensure we cover the discontinuities
+if ~isempty(basal_discontinuities)
+    tF = max(tF, max(basal_discontinuities) + timescale);
+end
+
+% Repeatedly simulate the timescale interval until we reach steady state
+reached_steady_state = false;
+while ~reached_steady_state
+    
+    % Integrate
+    sol_tmp = accumulateOdeFwdSimp(der, jac, t0, tF, ic, ...
+        basal_discontinuities, t0+timescale, ...
+        1:nx, reltol, abstol, [], [], []);
+    y_ss = sol_tmp.y(:,end);
+    
+    % Check for steady state
+    abs_diff = abs(y_ss - ic);
+    rel_diff = abs_diff ./ abs(ic);
+    max_err = max(min(abs_diff - abstol, rel_diff - reltol));
+    reached_steady_state = max_err <= 0;
+    
+    % Set up for next iteration
+    ic = y_ss;
+    t0 = tF;
+    tF = tF + timescale;
+    
+end
+
+end

--- a/Source/private/steadystateSens.m
+++ b/Source/private/steadystateSens.m
@@ -9,24 +9,17 @@ nTh = sum(opts.UseDoseControls);
 nT  = nTk + nTs + nTq + nTh;
 
 % Construct system
-[der, jac, eve] = constructSystem();
+[der, jac] = constructSystem();
 
 % Initial conditions [x0; vec(dxdT0)]
 order = 1;
 ic = extractICs(m,con,opts,order);
 
-% Check if already at steady state
-ssvalue = eve(0, ic);
-atSteadyState = ssvalue == 0;
-
-% If not at steady state, integrate until at steady state
-if ~atSteadyState
-    % Integrate [f; dfdT] over time
-    sol = accumulateOdeFwdSimp(der, jac, 0, inf, ic, con.private.BasalDiscontinuities, 0, 1:nx, opts.RelTol, opts.AbsTol(1:nx+nx*nT), [], eve, @(cum_sol)true);
-    
-    % Return steady-state value
-    ic = sol.ye;
-end
+abstol = opts.AbsTol(1:nx+nx*nT);
+reltol = opts.RelTol;
+basal_discontinuities = con.private.BasalDiscontinuities;
+timescale = con.private.TimeScale;
+ic = iterate_steady_state(der, jac, ic, nx, abstol, reltol, basal_discontinuities, timescale);
 
 % End of function
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -99,27 +92,5 @@ end
             val = [val(:,opts.UseParams), sparse(nx*nx, nTs), d2fdqdx(:,opts.UseInputControls), sparse(nx*nx,nTh)]; % fx_T
         end
         
-        % Steady-state event
-        function [value, isTerminal, direction] = events(t, joint)
-            u = uf(t);
-            x = joint(1:nx); % x_
-
-            % Absolute change
-            absDiff = con.private.TimeScale * f(-1,x,u); % Change over an entire simulation
-            
-            % Relative change
-            relDiff = absDiff ./ x;
-            
-            % Either absolute change or relative change must be less than
-            % the tolerance for all species
-            value = max(min(abs(absDiff) - opts.AbsTol(1:nx), abs(relDiff) - opts.RelTol));
-            if value < 0
-                value = 0;
-            end
-            
-            % Always end and only care about drops below the threshold
-            isTerminal = true;
-            direction = -1;
-        end
     end
 end

--- a/Source/private/steadystateSys.m
+++ b/Source/private/steadystateSys.m
@@ -4,24 +4,16 @@ function ic = steadystateSys(m, con, opts)
 nx = m.nx;
 
 % Construct system
-[der, jac, eve] = constructSystem();
+[der, jac] = constructSystem();
 
 order = 0;
 ic = extractICs(m,con,opts,order);
 
-% Check if already at steady state
-ssvalue = eve(0, ic);
-atSteadyState = ssvalue == 0;
-
-% If not at steady state, integrate until at steady state
-if ~atSteadyState
-    % Integrate f over time
-    %     accumulateOdeFwdSimp(der, jac, t0, tF, ic, discontinuities, t_get, nonnegative, RelTol, AbsTol, delta, events, is_finished)
-    sol = accumulateOdeFwdSimp(der, jac, 0, inf, ic, con.private.BasalDiscontinuities, 0, 1:nx, opts.RelTol, opts.AbsTol(1:nx), [], eve, @(cum_sol)true);
-    
-    % Return steady-state value
-    ic = sol.ye;
-end
+abstol = opts.AbsTol(1:nx);
+reltol = opts.RelTol;
+basal_discontinuities = con.private.BasalDiscontinuities;
+timescale = con.private.TimeScale;
+ic = iterate_steady_state(der, jac, ic, nx, abstol, reltol, basal_discontinuities, timescale);
 
 % End of function
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -30,6 +22,7 @@ end
 %%%%% The system for integrating f %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     function [der, jac, eve] = constructSystem()
+        
         f    = m.f;
         dfdx = m.dfdx;
         uf    = con.private.basal_u;
@@ -50,26 +43,6 @@ end
             val = dfdx(-1, x, u);
         end
         
-        % Steady-state event
-        function [value, isTerminal, direction] = events(t, x)
-            u = uf(t);
-
-            % Absolute change
-            absDiff = con.private.TimeScale * f(-1,x,u); % Change over an entire simulation
-            
-            % Relative change
-            relDiff = absDiff ./ x;
-            
-            % Either absolute change or relative change must be less than
-            % the tolerance for all species
-            value = max(min(abs(absDiff) - opts.AbsTol(1:nx), abs(relDiff) - opts.RelTol));
-            if value < 0
-                value = 0;
-            end
-            
-            % Always end and only care about drops below the threshold
-            isTerminal = true;
-            direction = -1;
-        end
     end
+
 end

--- a/Testing/UT03_CreatingExperiments.m
+++ b/Testing/UT03_CreatingExperiments.m
@@ -51,7 +51,7 @@ a.verifyEqual(con.s, m.s);
 a.verifyEqual(con.u(1), m.u);
 a.verifyEqual(con.d(1), zeros(m.ns,1));
 a.verifyEqual(con.private.BasalInput.u(5), m.u);
-a.verifyEqual(con.private.TimeScale, 10);
+a.verifyEqual(con.private.TimeScale, 100*24*60*60);
 a.verifyEqual(con.Periodic, false);
 a.verifyEqual(con.SteadyState, true);
 end
@@ -64,7 +64,7 @@ a.verifyEqual(con.s, s);
 a.verifyEqual(con.u(1), m.u);
 a.verifyEqual(con.d(1), zeros(m.ns,1));
 a.verifyEqual(con.private.BasalInput.u(5), m.u);
-a.verifyEqual(con.private.TimeScale, 10);
+a.verifyEqual(con.private.TimeScale, 100*24*60*60);
 end
 
 function testSteadyStateExperimentBasalInputConstant(a)
@@ -75,7 +75,7 @@ a.verifyEqual(con.s, m.s);
 a.verifyEqual(con.u(5), m.u);
 a.verifyEqual(con.d(1), zeros(m.ns,1));
 a.verifyEqual(con.private.BasalInput.u(5), basalu);
-a.verifyEqual(con.private.TimeScale, 10);
+a.verifyEqual(con.private.TimeScale, 100*24*60*60);
 end
 
 function testSteadyStateExperimentInputConstant(a)
@@ -86,7 +86,7 @@ a.verifyEqual(con.s, m.s);
 a.verifyEqual(con.u(5), u);
 a.verifyEqual(con.d(1), zeros(m.ns,1));
 a.verifyEqual(con.private.BasalInput.u(5), m.u);
-a.verifyEqual(con.private.TimeScale, 10);
+a.verifyEqual(con.private.TimeScale, 100*24*60*60);
 end
 
 function testSteadyStateExperimentDoseConstant(a)
@@ -99,7 +99,7 @@ a.verifyEqual(con.u(1), m.u);
 a.verifyEqual(con.d(1), d)
 a.verifyEqual(con.d(1.5), zeros(m.ns,1))
 a.verifyEqual(con.private.BasalInput.u(5), m.u);
-a.verifyEqual(con.private.TimeScale, 10);
+a.verifyEqual(con.private.TimeScale, 100*24*60*60);
 end
 
 function testSteadyStateExperimentTimeScale(a)


### PR DESCRIPTION
The original steady state method relies on comparing the value of the ODE RHS function against the tolerances, which is problematic because the ODE RHS can be very unstable, producing relatively large time derivatives even when the states are sufficiently close to their steady state. The result is that many simulations require a finely-tuned choice of TimeScale -- not too small, or the steady state isn't reached, but also not too large, or the integrator will stall. This can be particularly annoying when running multiple simulations, each of which might need its own tuned TimeScale value.

This new method repeatedly advances the integration by the TimeScale interval, comparing the starting and ending values of the states against their tolerances to determine when a steady state has been reached. The key advantage of this method is that choosing a large value for the TimeScale causes few problems, due to the adaptive time step size of the integrator allowing the steps to grow very large once the steady state is approached.  It also makes the TimeScale more intuitive, since now it is literally the time over which the states should change less than the tolerances when they are at steady state. It also makes it easy to implement a check against no steady state (not implemented yet, to be clear) -- simply limit the number of times the interval is simulated.